### PR TITLE
Replace JaCoCo internal API with public API

### DIFF
--- a/waitt-jacoco/pom.xml
+++ b/waitt-jacoco/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>net.unit8.waitt</groupId>
         <artifactId>waitt-parent</artifactId>
-        <version>1.4.0</version>
+        <version>1.4.1-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -22,6 +22,11 @@
             <groupId>org.jacoco</groupId>
             <artifactId>org.jacoco.core</artifactId>
             <version>${jacoco.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>9.7.1</version>
         </dependency>
 
         <dependency>

--- a/waitt-jacoco/src/main/java/net/unit8/waitt/feature/jacoco/JacocoClassLoader.java
+++ b/waitt-jacoco/src/main/java/net/unit8/waitt/feature/jacoco/JacocoClassLoader.java
@@ -1,11 +1,10 @@
 package net.unit8.waitt.feature.jacoco;
 
-import org.jacoco.agent.rt.internal_aeaf9ab.asm.MethodVisitor;
-import org.jacoco.agent.rt.internal_aeaf9ab.asm.Opcodes;
-import org.jacoco.agent.rt.internal_aeaf9ab.core.instr.Instrumenter;
-import org.jacoco.agent.rt.internal_aeaf9ab.core.internal.instr.InstrSupport;
-import org.jacoco.agent.rt.internal_aeaf9ab.core.runtime.IExecutionDataAccessorGenerator;
 import org.jacoco.core.JaCoCo;
+import org.jacoco.core.instr.Instrumenter;
+import org.jacoco.core.runtime.IExecutionDataAccessorGenerator;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -52,7 +51,13 @@ public class JacocoClassLoader extends URLClassLoader {
             public int generateDataAccessor(long classid, String classname, int probecount, MethodVisitor mv) {
                 mv.visitLdcInsn(Long.valueOf(classid));
                 mv.visitLdcInsn(classname);
-                InstrSupport.push(mv, probecount);
+                if (probecount <= Byte.MAX_VALUE) {
+                    mv.visitIntInsn(Opcodes.BIPUSH, probecount);
+                } else if (probecount <= Short.MAX_VALUE) {
+                    mv.visitIntInsn(Opcodes.SIPUSH, probecount);
+                } else {
+                    mv.visitLdcInsn(probecount);
+                }
                 mv.visitMethodInsn(Opcodes.INVOKESTATIC, JaCoCo.RUNTIMEPACKAGE.replace('.', '/') + "/Offline", "getProbes",
                         "(JLjava/lang/String;I)[Z", false);
                 return 4;

--- a/waitt-jacoco/src/main/java/net/unit8/waitt/feature/jacoco/JacocoMonitor.java
+++ b/waitt-jacoco/src/main/java/net/unit8/waitt/feature/jacoco/JacocoMonitor.java
@@ -6,8 +6,8 @@ import net.unit8.waitt.api.EmbeddedServer;
 import net.unit8.waitt.api.ServerMonitor;
 import net.unit8.waitt.api.configuration.WebappConfiguration;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
-import org.jacoco.agent.rt.internal_aeaf9ab.Agent;
-import org.jacoco.agent.rt.internal_aeaf9ab.core.runtime.AgentOptions;
+import org.jacoco.agent.rt.IAgent;
+import org.jacoco.agent.rt.RT;
 import org.jacoco.core.analysis.IBundleCoverage;
 import org.jacoco.core.data.ExecutionDataStore;
 import org.jacoco.core.tools.ExecFileLoader;
@@ -58,11 +58,8 @@ public class JacocoMonitor implements ServerMonitor,ConfigurableFeature {
             }
         });
 
-        final AgentOptions agentOptions = new AgentOptions();
-        agentOptions.setAppend(true);
-        agentOptions.setDumpOnExit(true);
         try {
-            final Agent agent = Agent.getInstance(agentOptions);
+            final IAgent agent = RT.getAgent();
             LOG.info("Start a jacoco agent. " + agent);
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -83,7 +80,7 @@ public class JacocoMonitor implements ServerMonitor,ConfigurableFeature {
             @Override
             public void run() {
                 try {
-                    Agent.getInstance().dump(false);
+                    RT.getAgent().dump(false);
                     ExecFileLoader loader = new ExecFileLoader();
                     loader.load(new File("jacoco.exec"));
                     final IReportVisitor visitor = createVisitor(Locale.getDefault());


### PR DESCRIPTION
## Summary

- Replace all `org.jacoco.agent.rt.internal_aeaf9ab.*` imports with public JaCoCo/ASM APIs
- `Instrumenter`, `IExecutionDataAccessorGenerator` → `org.jacoco.core.*`
- `MethodVisitor`, `Opcodes` → `org.objectweb.asm.*`
- `Agent`/`AgentOptions` → `RT.getAgent()`/`IAgent`
- Inline `InstrSupport.push()` with standard ASM instructions (BIPUSH/SIPUSH/LDC)
- Add explicit `org.ow2.asm:asm:9.7.1` dependency

This eliminates dependency on JaCoCo's shaded internal package (`internal_aeaf9ab`), which breaks on JaCoCo version upgrades when the hash suffix changes.

## Test plan

- [ ] `mvn clean compile -pl waitt-api,waitt-jacoco` passes
- [ ] `grep -r "internal_aeaf9ab" waitt-jacoco/` returns no results
- [ ] Coverage report generation works with spring-boot example

🤖 Generated with [Claude Code](https://claude.com/claude-code)