### PR TITLE
Bump h2 and commons-fileupload in examples/sa-struts

### DIFF
--- a/examples/sa-struts/pom.xml
+++ b/examples/sa-struts/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.5</version>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>


### PR DESCRIPTION
## Summary
- Bump `com.h2database:h2` from 1.4.200 to 2.2.220
- Bump `commons-fileupload:commons-fileupload` from 1.5 to 1.6.0

Supersedes #67 and #68 (Dependabot PRs targeting master).

## Test plan
- [ ] Verify `examples/sa-struts` builds with `mvn compile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)