### PR TITLE
Remove Lombok: replace @Data/@AllArgsConstructor with plain Java

### DIFF
--- a/examples/spring-boot/pom.xml
+++ b/examples/spring-boot/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.3</version>
+        <version>3.5.13</version>
     </parent>
     <groupId>net.unit8.waitt.example</groupId>
     <artifactId>spring-boot-example</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,13 +40,6 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.14.0</version>
                     <configuration>
-                        <annotationProcessorPaths>
-                            <path>
-                                <groupId>org.projectlombok</groupId>
-                                <artifactId>lombok</artifactId>
-                                <version>1.18.42</version>
-                            </path>
-                        </annotationProcessorPaths>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -151,14 +144,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok</artifactId>
-                <version>1.18.42</version>
-            </dependency>
-            <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-classworlds</artifactId>
-                <version>2.6.0</version>
+                <version>2.10.0</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
@@ -168,7 +156,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>4.5.0</version>
+                <version>4.11.0</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -178,7 +166,7 @@
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <version>2.11.0</version>
+                <version>2.13.2</version>
             </dependency>
             <dependency>
                 <groupId>org.gridkit.jvmtool</groupId>
@@ -188,7 +176,7 @@
             <dependency>
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-bom</artifactId>
-                <version>1.46.0</version>
+                <version>1.61.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/waitt-admin/pom.xml
+++ b/waitt-admin/pom.xml
@@ -40,11 +40,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
         </dependency>

--- a/waitt-api/pom.xml
+++ b/waitt-api/pom.xml
@@ -18,10 +18,5 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/waitt-api/src/main/java/net/unit8/waitt/api/configuration/Feature.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/configuration/Feature.java
@@ -3,13 +3,11 @@ package net.unit8.waitt.api.configuration;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
-import lombok.Data;
 
 /**
  *
  * @author kawasima
  */
-@Data
 public class Feature implements Serializable {
     private static final long serialVersionUID = 1L;
 
@@ -19,4 +17,19 @@ public class Feature implements Serializable {
     private String type;
 
     private Map<String, String> configuration = new HashMap<>();
+
+    public String getGroupId() { return groupId; }
+    public void setGroupId(String groupId) { this.groupId = groupId; }
+
+    public String getArtifactId() { return artifactId; }
+    public void setArtifactId(String artifactId) { this.artifactId = artifactId; }
+
+    public String getVersion() { return version; }
+    public void setVersion(String version) { this.version = version; }
+
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+
+    public Map<String, String> getConfiguration() { return configuration; }
+    public void setConfiguration(Map<String, String> configuration) { this.configuration = configuration; }
 }

--- a/waitt-api/src/main/java/net/unit8/waitt/api/configuration/FilterConfiguration.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/configuration/FilterConfiguration.java
@@ -1,18 +1,24 @@
 package net.unit8.waitt.api.configuration;
 
-import lombok.Data;
-
 import java.io.Serializable;
 import java.util.List;
 
 /**
  * @author kawasima
  */
-@Data
 public class FilterConfiguration implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private String name;
     private String className;
     private List<String> urlPatterns;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getClassName() { return className; }
+    public void setClassName(String className) { this.className = className; }
+
+    public List<String> getUrlPatterns() { return urlPatterns; }
+    public void setUrlPatterns(List<String> urlPatterns) { this.urlPatterns = urlPatterns; }
 }

--- a/waitt-api/src/main/java/net/unit8/waitt/api/configuration/Server.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/configuration/Server.java
@@ -1,16 +1,23 @@
 package net.unit8.waitt.api.configuration;
 
 import java.io.Serializable;
-import lombok.Data;
 
 /**
  * @author kawasima
  */
-@Data
 public class Server implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private String groupId;
     private String artifactId;
     private String version;
+
+    public String getGroupId() { return groupId; }
+    public void setGroupId(String groupId) { this.groupId = groupId; }
+
+    public String getArtifactId() { return artifactId; }
+    public void setArtifactId(String artifactId) { this.artifactId = artifactId; }
+
+    public String getVersion() { return version; }
+    public void setVersion(String version) { this.version = version; }
 }

--- a/waitt-api/src/main/java/net/unit8/waitt/api/configuration/WebappConfiguration.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/configuration/WebappConfiguration.java
@@ -6,13 +6,11 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import lombok.Data;
 
 /**
  *
  * @author kawasima
  */
-@Data
 public class WebappConfiguration implements Serializable {
     private static final long serialVersionUID = 1L;
 
@@ -21,6 +19,23 @@ public class WebappConfiguration implements Serializable {
     private File sourceDirectory;
     private File outputDirectory;
     private Set<String> packages = new HashSet<>();
-
     private List<Feature> features = new ArrayList<>();
+
+    public String getApplicationName() { return applicationName; }
+    public void setApplicationName(String applicationName) { this.applicationName = applicationName; }
+
+    public File getBaseDirectory() { return baseDirectory; }
+    public void setBaseDirectory(File baseDirectory) { this.baseDirectory = baseDirectory; }
+
+    public File getSourceDirectory() { return sourceDirectory; }
+    public void setSourceDirectory(File sourceDirectory) { this.sourceDirectory = sourceDirectory; }
+
+    public File getOutputDirectory() { return outputDirectory; }
+    public void setOutputDirectory(File outputDirectory) { this.outputDirectory = outputDirectory; }
+
+    public Set<String> getPackages() { return packages; }
+    public void setPackages(Set<String> packages) { this.packages = packages; }
+
+    public List<Feature> getFeatures() { return features; }
+    public void setFeatures(List<Feature> features) { this.features = features; }
 }

--- a/waitt-api/src/main/java/net/unit8/waitt/api/dto/ServerMetadata.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/dto/ServerMetadata.java
@@ -1,13 +1,17 @@
 package net.unit8.waitt.api.dto;
 
-import lombok.Data;
 import net.unit8.waitt.api.ServerStatus;
 
 /**
  * @author kawasima
  */
-@Data
 public class ServerMetadata {
     private String name;
     private ServerStatus status;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public ServerStatus getStatus() { return status; }
+    public void setStatus(ServerStatus status) { this.status = status; }
 }

--- a/waitt-embed-runner/pom.xml
+++ b/waitt-embed-runner/pom.xml
@@ -19,11 +19,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>net.unit8.waitt</groupId>
             <artifactId>waitt-api</artifactId>
             <version>${project.parent.version}</version>

--- a/waitt-jacoco/pom.xml
+++ b/waitt-jacoco/pom.xml
@@ -46,11 +46,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
         </dependency>

--- a/waitt-jetty12/pom.xml
+++ b/waitt-jetty12/pom.xml
@@ -14,7 +14,7 @@
     </parent>
 
     <properties>
-        <jetty.version>12.1.6</jetty.version>
+        <jetty.version>12.1.8</jetty.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
     </properties>

--- a/waitt-maven-plugin/pom.xml
+++ b/waitt-maven-plugin/pom.xml
@@ -12,7 +12,7 @@
     <packaging>maven-plugin</packaging>
 
     <properties>
-        <maven.version>3.9.9</maven.version>
+        <maven.version>3.9.14</maven.version>
         <mavenPluginPluginVersion>3.15.2</mavenPluginPluginVersion>
         <maven.archiver.version>3.6.6</maven.archiver.version>
     </properties>
@@ -110,11 +110,6 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.fusesource.jansi</groupId>

--- a/waitt-maven-plugin/src/main/java/net/unit8/waitt/mojo/configuration/DockerConfiguration.java
+++ b/waitt-maven-plugin/src/main/java/net/unit8/waitt/mojo/configuration/DockerConfiguration.java
@@ -1,7 +1,5 @@
 package net.unit8.waitt.mojo.configuration;
 
-import lombok.Data;
-
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
@@ -11,7 +9,6 @@ import java.util.List;
  *
  * @author kawasima
  */
-@Data
 public class DockerConfiguration implements Serializable {
     private static final long serialVersionUID = 1L;
 
@@ -21,4 +18,22 @@ public class DockerConfiguration implements Serializable {
     private List<Integer> ports = Collections.singletonList(8080);
     private String javaOpts = "";
     private String to = "daemon";
+
+    public String getBaseImage() { return baseImage; }
+    public void setBaseImage(String baseImage) { this.baseImage = baseImage; }
+
+    public String getImageName() { return imageName; }
+    public void setImageName(String imageName) { this.imageName = imageName; }
+
+    public String getImageTag() { return imageTag; }
+    public void setImageTag(String imageTag) { this.imageTag = imageTag; }
+
+    public List<Integer> getPorts() { return ports; }
+    public void setPorts(List<Integer> ports) { this.ports = ports; }
+
+    public String getJavaOpts() { return javaOpts; }
+    public void setJavaOpts(String javaOpts) { this.javaOpts = javaOpts; }
+
+    public String getTo() { return to; }
+    public void setTo(String to) { this.to = to; }
 }

--- a/waitt-maven-plugin/src/main/java/net/unit8/waitt/mojo/configuration/ExtraWebapp.java
+++ b/waitt-maven-plugin/src/main/java/net/unit8/waitt/mojo/configuration/ExtraWebapp.java
@@ -1,17 +1,23 @@
 package net.unit8.waitt.mojo.configuration;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
 
 /**
  *
  * @author kawasima
  */
-@Data
-@AllArgsConstructor
 public class ExtraWebapp {
-    private String name;
-    private String warPath;
-    private ClassRealm realm;
+    private final String name;
+    private final String warPath;
+    private final ClassRealm realm;
+
+    public ExtraWebapp(String name, String warPath, ClassRealm realm) {
+        this.name = name;
+        this.warPath = warPath;
+        this.realm = realm;
+    }
+
+    public String getName() { return name; }
+    public String getWarPath() { return warPath; }
+    public ClassRealm getRealm() { return realm; }
 }

--- a/waitt-tomcat10/pom.xml
+++ b/waitt-tomcat10/pom.xml
@@ -14,7 +14,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <tomcat.version>10.1.52</tomcat.version>
+        <tomcat.version>10.1.54</tomcat.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
     </properties>

--- a/waitt-tomcat11/pom.xml
+++ b/waitt-tomcat11/pom.xml
@@ -14,7 +14,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <tomcat.version>11.0.18</tomcat.version>
+        <tomcat.version>11.0.21</tomcat.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
     </properties>

--- a/waitt-tomcat9/pom.xml
+++ b/waitt-tomcat9/pom.xml
@@ -15,7 +15,7 @@
 
 
     <properties>
-        <tomcat.version>9.0.115</tomcat.version>
+        <tomcat.version>9.0.117</tomcat.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary

- Remove Lombok \`@Data\` and \`@AllArgsConstructor\` from all production source files
- Replace with hand-written getters and setters (Java 8 target — Records not available)
- \`ExtraWebapp\` is made immutable (final fields, constructor + getters only, no setters)
- All other configuration classes retain setters since they are populated by the Maven XML parser or setter calls at runtime
- Also bump several managed dependency versions that were outdated alongside the Lombok removal commit

## Changed files

**waitt-api** (5 files):
- \`Feature.java\` — getter + setter for all fields
- \`FilterConfiguration.java\` — getter + setter for all fields
- \`Server.java\` — getter + setter for all fields
- \`WebappConfiguration.java\` — getter + setter for all fields
- \`ServerMetadata.java\` — getter + setter for both fields

**waitt-maven-plugin** (2 files):
- \`ExtraWebapp.java\` — constructor + getters only (immutable)
- \`DockerConfiguration.java\` — getter + setter for all fields

**pom.xml cleanup / dependency upgrades** (6 files):
- Parent \`pom.xml\`: removed \`lombok\` from \`<dependencyManagement>\` and \`<annotationProcessorPaths>\`
- Bumped: \`plexus-classworlds\` 2.6.0→2.10.0, \`mockito-core\` 4.5.0→4.11.0, \`gson\` 2.11.0→2.13.2, \`opentelemetry-bom\` 1.46.0→1.61.0
- Bumped: Tomcat 9/10/11, Jetty 12, Maven plugin versions, Spring Boot (examples)
- \`waitt-api/pom.xml\`, \`waitt-maven-plugin/pom.xml\`, \`waitt-admin/pom.xml\`, \`waitt-embed-runner/pom.xml\`, \`waitt-jacoco/pom.xml\`: removed lombok dependency

## Test plan

- [x] \`mvn clean compile -q\` passes with no errors
- [x] \`rg "import lombok"\` returns only \`examples/sa-struts\` (intentionally out of scope)
- [x] Dependency version bumps are minor/patch upgrades; no API-breaking changes expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)