### PR TITLE
chore(deps): Bump tomcat-embed-core (9.0.118 / 10.1.55 / 11.0.22)

### DIFF
--- a/waitt-tomcat10/pom.xml
+++ b/waitt-tomcat10/pom.xml
@@ -14,7 +14,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <tomcat.version>10.1.54</tomcat.version>
+        <tomcat.version>10.1.55</tomcat.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
     </properties>

--- a/waitt-tomcat11/pom.xml
+++ b/waitt-tomcat11/pom.xml
@@ -14,7 +14,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <tomcat.version>11.0.21</tomcat.version>
+        <tomcat.version>11.0.22</tomcat.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
     </properties>

--- a/waitt-tomcat9/pom.xml
+++ b/waitt-tomcat9/pom.xml
@@ -15,7 +15,7 @@
 
 
     <properties>
-        <tomcat.version>9.0.117</tomcat.version>
+        <tomcat.version>9.0.118</tomcat.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Applies the Dependabot updates from #96, #97, #98 against `develop`.

On `develop` the Tomcat version is centralized in each module's `<tomcat.version>` property, so the original Dependabot branches (which edit the old hardcoded `<version>` line) conflict structurally. This PR bumps the properties instead:

- `waitt-tomcat9`: 9.0.117 → **9.0.118**
- `waitt-tomcat10`: 10.1.54 → **10.1.55**
- `waitt-tomcat11`: 11.0.21 → **11.0.22**

Supersedes #96 / #97 / #98. All three modules build with the new versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)