### PR TITLE
feat(observability): Correlated trace store + waterfall UI (SP1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,9 @@ request detail — a span waterfall plus the logs and exception for that request
 with no external stack required.
 
 Note: waitt-tracer uses the Jakarta Servlet API, so the Traces view is only
-available on Tomcat 10/11 and Jetty 12.
+available on Tomcat 10/11 and Jetty 12. Correlation is thread-bound, so it covers
+synchronous request handling; work an app dispatches to other threads (async
+servlets) is not correlated to its request.
 
 ```xml
   <feature>

--- a/README.md
+++ b/README.md
@@ -180,11 +180,13 @@ The log buffer size is configurable (default 1000 lines):
 
 ### Tracer
 
-`waitt-tracer` creates an OpenTelemetry span for each HTTP request. Spans are both
-exported over OTLP (to an external collector such as Jaeger) **and** retained
-in-process so the admin dashboard's **Traces** page can show a correlated
-request detail — a span waterfall plus the logs and exception for that request —
-with no external stack required.
+`waitt-tracer` creates an OpenTelemetry span for each HTTP request. Spans are
+always retained in-process so the admin dashboard's **Traces** page can show a
+correlated request detail — a span waterfall plus the logs and exception for that
+request — with no external stack required. OTLP export to an external collector
+(such as Jaeger) is opt-in: it happens only when you set `otel.endpoint`. Leave it
+unset and the tracer runs purely in-process, so no collector is required and no
+connection errors are logged.
 
 Note: waitt-tracer uses the Jakarta Servlet API, so the Traces view is only
 available on Tomcat 10/11 and Jetty 12. Correlation is thread-bound, so it covers
@@ -197,7 +199,7 @@ servlets) is not correlated to its request.
     <artifactId>waitt-tracer</artifactId>
     <version>1.5.1-SNAPSHOT</version>
     <configuration>
-      <!-- OTLP/HTTP collector endpoint (default http://localhost:4318) -->
+      <!-- Optional: OTLP/HTTP collector endpoint. Omit to run in-process only. -->
       <otel.endpoint>http://localhost:4318</otel.endpoint>
       <!-- number of recent traces kept for the dashboard (default 100) -->
       <trace.retention.size>100</trace.retention.size>

--- a/README.md
+++ b/README.md
@@ -180,8 +180,14 @@ The log buffer size is configurable (default 1000 lines):
 
 ### Tracer
 
-You can show and search HTTP request/response logs at development in Kibana.
-Note: waitt-tracer uses the Jakarta Servlet API, so it is only compatible with Tomcat 10/11 and Jetty 12.
+`waitt-tracer` creates an OpenTelemetry span for each HTTP request. Spans are both
+exported over OTLP (to an external collector such as Jaeger) **and** retained
+in-process so the admin dashboard's **Traces** page can show a correlated
+request detail — a span waterfall plus the logs and exception for that request —
+with no external stack required.
+
+Note: waitt-tracer uses the Jakarta Servlet API, so the Traces view is only
+available on Tomcat 10/11 and Jetty 12.
 
 ```xml
   <feature>
@@ -189,10 +195,15 @@ Note: waitt-tracer uses the Jakarta Servlet API, so it is only compatible with T
     <artifactId>waitt-tracer</artifactId>
     <version>1.5.1-SNAPSHOT</version>
     <configuration>
-      <elasticsearch.url>http://[es host]:9200</elasticsearch.url>
+      <!-- OTLP/HTTP collector endpoint (default http://localhost:4318) -->
+      <otel.endpoint>http://localhost:4318</otel.endpoint>
+      <!-- number of recent traces kept for the dashboard (default 100) -->
+      <trace.retention.size>100</trace.retention.size>
     </configuration>
   </feature>
 ```
+
+Pair it with `waitt-admin` to view the Traces page at `http://localhost:1192/#traces`.
 
 ### DevTools (Auto-Reload)
 

--- a/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/AdminServer.java
+++ b/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/AdminServer.java
@@ -6,6 +6,8 @@ import net.unit8.waitt.api.EmbeddedServer;
 import net.unit8.waitt.api.ServerMonitor;
 import net.unit8.waitt.api.configuration.Feature;
 import net.unit8.waitt.api.configuration.WebappConfiguration;
+import net.unit8.waitt.api.observability.RequestTrace;
+import net.unit8.waitt.api.observability.TraceStore;
 import net.unit8.waitt.feature.admin.json.JSONObject;
 import net.unit8.waitt.feature.admin.routes.*;
 
@@ -100,6 +102,7 @@ public class AdminServer implements ServerMonitor, ConfigurableFeature {
         app.addRoutes(new PrometheusAction(metrics));
         app.addRoutes(new StreamAction(broadcaster));
         app.addRoutes(new LogsAction(logBuffer));
+        app.addRoutes(new TracesAction());
 
         rrdPath = "target/rrd/" + config.getApplicationName() + ".rrd";
     }
@@ -118,6 +121,15 @@ public class AdminServer implements ServerMonitor, ConfigurableFeature {
                     metrics.recordHttpRequest(method, status, durationMs);
                 } catch (RuntimeException e) {
                     LOG.log(Level.FINE, "Failed to record request telemetry", e);
+                }
+            }
+        });
+        // Push completed traces to the dashboard live.
+        TraceStore.getInstance().setListener(new TraceStore.TraceListener() {
+            @Override
+            public void onTraceCompleted(RequestTrace trace) {
+                if (broadcaster.hasSubscribers()) {
+                    broadcaster.publish("trace", TracesAction.summary(trace).toJSONString());
                 }
             }
         });
@@ -194,6 +206,7 @@ public class AdminServer implements ServerMonitor, ConfigurableFeature {
         if (metricsScheduler != null) {
             metricsScheduler.shutdownNow();
         }
+        TraceStore.getInstance().setListener(null);
         broadcaster.shutdown();
         System.getProperties().remove(RequestLogAction.LOG_KEY);
         if (metrics != null) {

--- a/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/ConsoleCapture.java
+++ b/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/ConsoleCapture.java
@@ -72,8 +72,12 @@ public class ConsoleCapture {
         LogEntry entry = new LogEntry(now, streamName, line);
         buffer.add(entry);
         // Correlate to the in-flight request when this line was written on a
-        // request thread (no-op when tracing is off or no trace is current).
-        TraceStore.getInstance().recordLog(new LogLine(now, streamName, line));
+        // request thread. Guard on isEnabled() so the common no-tracer case does
+        // not allocate a throwaway LogLine per console line.
+        TraceStore store = TraceStore.getInstance();
+        if (store.isEnabled()) {
+            store.recordLog(new LogLine(now, streamName, line));
+        }
         if (broadcaster.hasSubscribers()) {
             broadcaster.publish("log", entry.toJSON().toJSONString());
         }

--- a/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/ConsoleCapture.java
+++ b/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/ConsoleCapture.java
@@ -1,5 +1,8 @@
 package net.unit8.waitt.feature.admin;
 
+import net.unit8.waitt.api.observability.LogLine;
+import net.unit8.waitt.api.observability.TraceStore;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -65,8 +68,12 @@ public class ConsoleCapture {
     }
 
     private void emit(String streamName, String line) {
-        LogEntry entry = new LogEntry(System.currentTimeMillis(), streamName, line);
+        long now = System.currentTimeMillis();
+        LogEntry entry = new LogEntry(now, streamName, line);
         buffer.add(entry);
+        // Correlate to the in-flight request when this line was written on a
+        // request thread (no-op when tracing is off or no trace is current).
+        TraceStore.getInstance().recordLog(new LogLine(now, streamName, line));
         if (broadcaster.hasSubscribers()) {
             broadcaster.publish("log", entry.toJSON().toJSONString());
         }

--- a/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/routes/TracesAction.java
+++ b/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/routes/TracesAction.java
@@ -1,0 +1,150 @@
+package net.unit8.waitt.feature.admin.routes;
+
+import com.sun.net.httpserver.HttpExchange;
+import net.unit8.waitt.api.observability.LogLine;
+import net.unit8.waitt.api.observability.RequestTrace;
+import net.unit8.waitt.api.observability.SpanRecord;
+import net.unit8.waitt.api.observability.SqlEvent;
+import net.unit8.waitt.api.observability.TraceStore;
+import net.unit8.waitt.feature.admin.ResponseUtils;
+import net.unit8.waitt.feature.admin.Route;
+import net.unit8.waitt.feature.admin.json.JSONObject;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Serves the correlated request traces from {@link TraceStore}:
+ * {@code GET /traces} lists recent traces (summaries), {@code GET /traces/{id}}
+ * returns one trace's full detail (spans, SQL, logs, exception). Live updates
+ * arrive over {@code /stream} as {@code trace} events.
+ *
+ * @author kawasima
+ */
+public class TracesAction implements Route {
+    private static final String PREFIX = "/traces";
+
+    @Override
+    public boolean canHandle(HttpExchange exchange) {
+        if (!"GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+            return false;
+        }
+        String path = exchange.getRequestURI().getPath();
+        return PREFIX.equals(path) || path.startsWith(PREFIX + "/");
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        String path = exchange.getRequestURI().getPath();
+        if (PREFIX.equals(path)) {
+            handleList(exchange);
+        } else {
+            handleDetail(exchange, path.substring(PREFIX.length() + 1));
+        }
+    }
+
+    private void handleList(HttpExchange exchange) throws IOException {
+        List<RequestTrace> traces = TraceStore.getInstance().recentTraces();
+        List<JSONObject> list = new ArrayList<JSONObject>(traces.size());
+        for (RequestTrace trace : traces) {
+            list.add(summary(trace));
+        }
+        JSONObject json = new JSONObject();
+        json.put("traces", list);
+        json.put("total", traces.size());
+        ResponseUtils.responseJSON(exchange, json);
+    }
+
+    private void handleDetail(HttpExchange exchange, String traceId) throws IOException {
+        RequestTrace trace = TraceStore.getInstance().getTrace(traceId);
+        if (trace == null) {
+            ResponseUtils.sendError(exchange, 404, "Trace not found");
+            return;
+        }
+        ResponseUtils.responseJSON(exchange, detail(trace));
+    }
+
+    public static JSONObject summary(RequestTrace trace) {
+        JSONObject o = new JSONObject();
+        o.put("traceId", trace.getTraceId());
+        o.put("method", trace.getMethod());
+        o.put("path", trace.getPath());
+        o.put("statusCode", trace.getStatusCode());
+        o.put("startEpochMillis", trace.getStartEpochMillis());
+        o.put("durationMillis", trace.getDurationMillis());
+        o.put("spanCount", trace.getSpans().size());
+        o.put("sqlCount", trace.getSqlEvents().size());
+        o.put("logCount", trace.getLogs().size());
+        o.put("hasError", trace.getExceptionType() != null || trace.getStatusCode() >= 500);
+        return o;
+    }
+
+    private JSONObject detail(RequestTrace trace) {
+        JSONObject o = summary(trace);
+
+        // Absolute epoch nanos (~1.8e18) exceed JS's safe-integer range, so emit
+        // offsets relative to the earliest span start (small longs the browser can
+        // position exactly) plus the total window for the waterfall.
+        long minStart = Long.MAX_VALUE;
+        long maxEnd = Long.MIN_VALUE;
+        for (SpanRecord span : trace.getSpans()) {
+            minStart = Math.min(minStart, span.getStartEpochNanos());
+            maxEnd = Math.max(maxEnd, span.getEndEpochNanos());
+        }
+        long windowNanos = trace.getSpans().isEmpty() ? 0 : (maxEnd - minStart);
+        o.put("windowNanos", windowNanos);
+
+        List<JSONObject> spans = new ArrayList<JSONObject>();
+        for (SpanRecord span : trace.getSpans()) {
+            JSONObject s = new JSONObject();
+            s.put("spanId", span.getSpanId());
+            s.put("parentSpanId", span.getParentSpanId());
+            s.put("name", span.getName());
+            s.put("startOffsetNanos", span.getStartEpochNanos() - minStart);
+            s.put("durationNanos", span.getDurationNanos());
+            s.put("error", span.isError());
+            s.put("database", span.isDatabase());
+            JSONObject attrs = new JSONObject();
+            for (Map.Entry<String, String> e : span.getAttributes().entrySet()) {
+                attrs.put(e.getKey(), e.getValue());
+            }
+            s.put("attributes", attrs);
+            spans.add(s);
+        }
+        o.put("spans", spans);
+
+        List<JSONObject> sqls = new ArrayList<JSONObject>();
+        for (SqlEvent sql : trace.getSqlEvents()) {
+            JSONObject q = new JSONObject();
+            q.put("startEpochMillis", sql.getStartEpochMillis());
+            q.put("durationMillis", sql.getDurationMillis());
+            q.put("sql", sql.getSql());
+            q.put("rowCount", sql.getRowCount());
+            q.put("success", sql.isSuccess());
+            q.put("error", sql.getError());
+            sqls.add(q);
+        }
+        o.put("sqlEvents", sqls);
+
+        List<JSONObject> logs = new ArrayList<JSONObject>();
+        for (LogLine line : trace.getLogs()) {
+            JSONObject l = new JSONObject();
+            l.put("timestamp", line.getTimestampMillis());
+            l.put("stream", line.getStream());
+            l.put("text", line.getText());
+            logs.add(l);
+        }
+        o.put("logs", logs);
+
+        if (trace.getExceptionType() != null) {
+            JSONObject ex = new JSONObject();
+            ex.put("type", trace.getExceptionType());
+            ex.put("message", trace.getExceptionMessage());
+            ex.put("stack", trace.getExceptionStack());
+            o.put("exception", ex);
+        }
+        return o;
+    }
+}

--- a/waitt-admin/src/main/resources/public/css/dashboard.css
+++ b/waitt-admin/src/main/resources/public/css/dashboard.css
@@ -170,3 +170,35 @@ tr.req-5xx td { background: #fdecea; }
 .log-line.log-warn { color: #dcdc7d; }
 .log-line.log-error { color: #f48771; }
 .metrics-scrape { max-height: 60vh; overflow: auto; background: #f8f8f8; padding: .5rem; }
+
+/* Traces */
+tr.trace-row { cursor: pointer; }
+tr.trace-row:hover td { background: #ede9f7; }
+.back-link { display: inline-block; padding: .2rem 0; margin-bottom: .5rem; color: #463381; font-weight: bold; }
+
+/* Waterfall */
+.waterfall { margin-bottom: 1rem; }
+.wf-row { display: flex; align-items: center; margin-bottom: 2px; }
+.wf-label {
+    width: 34%;
+    flex-shrink: 0;
+    font-size: .8em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding-right: .5rem;
+}
+.wf-track { position: relative; flex: 1; height: 18px; background: #f2f2f2; border-radius: 2px; }
+.wf-bar {
+    position: absolute;
+    top: 0;
+    height: 18px;
+    min-width: 2px;
+    background: #6b8fd6;
+    border-radius: 2px;
+    overflow: hidden;
+}
+.wf-bar.wf-db { background: #4caf72; }
+.wf-bar.wf-error { background: #e06c62; }
+.wf-dur { font-size: .7em; color: #fff; padding: 0 .25rem; line-height: 18px; white-space: nowrap; }
+code { font-family: monospace; font-size: .95em; word-break: break-all; }

--- a/waitt-admin/src/main/resources/public/index.html
+++ b/waitt-admin/src/main/resources/public/index.html
@@ -19,6 +19,7 @@
         <li><a class="nav-link" data-page="server">Server</a></li>
         <li><a class="nav-link" data-page="metrics">Metrics</a></li>
         <li><a class="nav-link" data-page="requests">Request Log</a></li>
+        <li><a class="nav-link" data-page="traces">Traces</a></li>
         <li><a class="nav-link" data-page="logs">Logs</a></li>
         <li><a class="nav-link" data-page="loggers">Loggers</a></li>
         <li><a class="nav-link" data-page="thread">Thread dump</a></li>
@@ -64,6 +65,8 @@
       // them so stream events can't append to a detached, off-screen subtree.
       live.requestsTbody = null;
       live.requestsEmpty = null;
+      live.tracesTbody = null;
+      live.tracesEmpty = null;
       live.logsView = null;
       var c = document.getElementById('content');
       c.innerHTML = '';
@@ -346,6 +349,132 @@
       }).catch(function (e) { setContent(errorMsg(e.message)); });
     }
 
+    function traceRow(t) {
+      var time = t.startEpochMillis ? new Date(t.startEpochMillis).toLocaleTimeString() : '';
+      var cls = t.hasError ? 'req-5xx' : (t.statusCode >= 400 ? 'req-4xx' : '');
+      var counts = (t.spanCount || 0) + 's / ' + (t.sqlCount || 0) + 'q / ' + (t.logCount || 0) + 'log';
+      var row = h('tr', { class: (cls ? cls + ' ' : '') + 'trace-row' }, [
+        h('td', {}, [time]),
+        h('td', {}, [t.method || '']),
+        h('td', {}, [t.path || '']),
+        h('td', {}, [String(t.statusCode || '')]),
+        h('td', {}, [t.durationMillis >= 0 ? t.durationMillis + 'ms' : '']),
+        h('td', {}, [counts]),
+      ]);
+      row.addEventListener('click', function () { showTraceDetail(t.traceId); });
+      return row;
+    }
+
+    function pageTraces() {
+      var token = live.navToken;
+      setContent(loading());
+      apiFetch('/traces').then(function (data) {
+        if (token !== live.navToken) return;
+        var traces = data.traces || [];
+        var div = h('div', {});
+        div.appendChild(h('h2', {}, ['Traces ', h('span', { class: 'live-badge' }, ['live'])]));
+        div.appendChild(h('p', { class: 'text-muted' }, ['Click a row for the correlated request detail (waterfall, SQL, logs, exception). Requires waitt-tracer.']));
+        var table = h('table', {});
+        table.appendChild(h('thead', {}, [h('tr', {}, [
+          h('th', {}, ['Time']), h('th', {}, ['Method']), h('th', {}, ['Path']),
+          h('th', {}, ['Status']), h('th', {}, ['Duration']), h('th', {}, ['spans/sql/logs'])
+        ])]));
+        var tbody = h('tbody', {});
+        traces.forEach(function (t) { tbody.appendChild(traceRow(t)); });
+        table.appendChild(tbody);
+        div.appendChild(table);
+        var empty = h('p', { class: 'text-muted' }, ['No traces yet. Send a request to your app.']);
+        if (traces.length) empty.style.display = 'none';
+        div.appendChild(empty);
+        setContent(div);
+        live.tracesTbody = tbody;
+        live.tracesEmpty = empty;
+      }).catch(function (e) { setContent(errorMsg(e.message)); });
+    }
+
+    function renderWaterfall(spans, windowNanos) {
+      var wrap = h('div', { class: 'waterfall' });
+      if (!spans.length) { wrap.appendChild(h('p', { class: 'text-muted' }, ['No spans.'])); return wrap; }
+      var win = Math.max(1, windowNanos || 0);
+      spans.slice().sort(function (a, b) { return a.startOffsetNanos - b.startOffsetNanos; }).forEach(function (s) {
+        var left = (s.startOffsetNanos / win) * 100;
+        var width = Math.max(0.4, (s.durationNanos / win) * 100);
+        var ms = (s.durationNanos / 1e6).toFixed(1) + 'ms';
+        var barCls = 'wf-bar' + (s.error ? ' wf-error' : (s.database ? ' wf-db' : ''));
+        var bar = h('div', { class: barCls }, [h('span', { class: 'wf-dur' }, [ms])]);
+        bar.style.left = left + '%';
+        bar.style.width = width + '%';
+        bar.title = s.name + ' — ' + ms;
+        var row = h('div', { class: 'wf-row' }, [
+          h('div', { class: 'wf-label', title: s.name }, [s.name]),
+          h('div', { class: 'wf-track' }, [bar]),
+        ]);
+        wrap.appendChild(row);
+      });
+      return wrap;
+    }
+
+    function showTraceDetail(traceId) {
+      live.tracesTbody = null;
+      setContent(loading());
+      apiFetch('/traces/' + encodeURIComponent(traceId)).then(function (t) {
+        var div = h('div', {});
+        var back = h('a', { class: 'nav-link back-link' }, ['← Traces']);
+        back.addEventListener('click', pageTraces);
+        div.appendChild(back);
+        div.appendChild(h('h2', {}, [(t.method || '') + ' ' + (t.path || '')]));
+        var meta = h('p', { class: 'text-muted' }, [
+          'Status ' + (t.statusCode || '?') + ' · ' + (t.durationMillis >= 0 ? t.durationMillis + 'ms' : '?') +
+          ' · trace ' + t.traceId
+        ]);
+        div.appendChild(meta);
+
+        if (t.exception) {
+          div.appendChild(h('h3', { class: 'text-danger' }, ['Exception: ' + (t.exception.type || '')]));
+          div.appendChild(h('p', {}, [t.exception.message || '']));
+          if (t.exception.stack) {
+            var pre = document.createElement('pre'); pre.className = 'stack-trace'; pre.textContent = t.exception.stack;
+            div.appendChild(pre);
+          }
+        }
+
+        div.appendChild(h('h3', {}, ['Timeline']));
+        div.appendChild(renderWaterfall(t.spans || [], t.windowNanos));
+
+        var sqls = t.sqlEvents || [];
+        div.appendChild(h('h3', {}, ['SQL (' + sqls.length + ')']));
+        if (sqls.length) {
+          var sqlTable = h('table', {});
+          sqlTable.appendChild(h('thead', {}, [h('tr', {}, [h('th', {}, ['#']), h('th', {}, ['Duration']), h('th', {}, ['Rows']), h('th', {}, ['Statement'])])]));
+          var sb = h('tbody', {});
+          sqls.forEach(function (q, i) {
+            sb.appendChild(h('tr', q.success ? {} : { class: 'req-5xx' }, [
+              h('td', {}, [String(i + 1)]),
+              h('td', {}, [q.durationMillis + 'ms']),
+              h('td', {}, [q.rowCount >= 0 ? String(q.rowCount) : '']),
+              h('td', {}, [h('code', {}, [q.sql || (q.error || '')])]),
+            ]));
+          });
+          sqlTable.appendChild(sb);
+          div.appendChild(sqlTable);
+        } else {
+          div.appendChild(h('p', { class: 'text-muted' }, ['No SQL captured (requires waitt-jdbc).']));
+        }
+
+        var logs = t.logs || [];
+        div.appendChild(h('h3', {}, ['Logs (' + logs.length + ')']));
+        if (logs.length) {
+          var lv = h('div', { class: 'log-view' });
+          logs.forEach(function (entry) { lv.appendChild(logLineNode(entry)); });
+          div.appendChild(lv);
+        } else {
+          div.appendChild(h('p', { class: 'text-muted' }, ['No correlated logs.']));
+        }
+
+        setContent(div);
+      }).catch(function (e) { setContent(errorMsg(e.message)); });
+    }
+
     function pageMetrics() {
       setContent(loading());
       fetch(BASE + '/prometheus', { headers: { Accept: 'text/plain' } })
@@ -544,6 +673,8 @@
       navToken: 0,
       requestsTbody: null,
       requestsEmpty: null,
+      tracesTbody: null,
+      tracesEmpty: null,
       logsView: null,
       logEntries: [],
       logFilter: '',
@@ -582,6 +713,16 @@
       }
     }
 
+    function onTraceEvent(e) {
+      if (!live.tracesTbody) return;
+      var t = JSON.parse(e.data);
+      live.tracesTbody.insertBefore(traceRow(t), live.tracesTbody.firstChild);
+      if (live.tracesEmpty) live.tracesEmpty.style.display = 'none';
+      while (live.tracesTbody.childNodes.length > 200) {
+        live.tracesTbody.removeChild(live.tracesTbody.lastChild);
+      }
+    }
+
     function onMetricsEvent(e) {
       var el = document.getElementById('live-indicator');
       if (!el) return;
@@ -596,6 +737,7 @@
       es.addEventListener('open', function () { setIndicator('on'); });
       es.addEventListener('error', function () { setIndicator('off'); });
       es.addEventListener('request', onRequestEvent);
+      es.addEventListener('trace', onTraceEvent);
       es.addEventListener('log', onLogEvent);
       es.addEventListener('metrics', onMetricsEvent);
     }
@@ -607,6 +749,7 @@
       server: pageServer,
       metrics: pageMetrics,
       requests: pageRequests,
+      traces: pageTraces,
       logs: pageLogs,
       loggers: pageLoggers,
       thread: pageThread,

--- a/waitt-admin/src/main/resources/public/index.html
+++ b/waitt-admin/src/main/resources/public/index.html
@@ -353,7 +353,7 @@
       var time = t.startEpochMillis ? new Date(t.startEpochMillis).toLocaleTimeString() : '';
       var cls = t.hasError ? 'req-5xx' : (t.statusCode >= 400 ? 'req-4xx' : '');
       var counts = (t.spanCount || 0) + 's / ' + (t.sqlCount || 0) + 'q / ' + (t.logCount || 0) + 'log';
-      var row = h('tr', { class: (cls ? cls + ' ' : '') + 'trace-row' }, [
+      var row = h('tr', { class: (cls ? cls + ' ' : '') + 'trace-row', 'data-trace-id': t.traceId }, [
         h('td', {}, [time]),
         h('td', {}, [t.method || '']),
         h('td', {}, [t.path || '']),
@@ -415,9 +415,11 @@
     }
 
     function showTraceDetail(traceId) {
+      var token = live.navToken;
       live.tracesTbody = null;
       setContent(loading());
       apiFetch('/traces/' + encodeURIComponent(traceId)).then(function (t) {
+        if (token !== live.navToken) return; // navigated away before this resolved
         var div = h('div', {});
         var back = h('a', { class: 'nav-link back-link' }, ['← Traces']);
         back.addEventListener('click', pageTraces);
@@ -716,6 +718,8 @@
     function onTraceEvent(e) {
       if (!live.tracesTbody) return;
       var t = JSON.parse(e.data);
+      // The /traces snapshot and this live event can race; skip if already shown.
+      if (t.traceId && live.tracesTbody.querySelector('[data-trace-id="' + t.traceId + '"]')) return;
       live.tracesTbody.insertBefore(traceRow(t), live.tracesTbody.firstChild);
       if (live.tracesEmpty) live.tracesEmpty.style.display = 'none';
       while (live.tracesTbody.childNodes.length > 200) {

--- a/waitt-api/src/main/java/net/unit8/waitt/api/observability/LogLine.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/observability/LogLine.java
@@ -1,0 +1,24 @@
+package net.unit8.waitt.api.observability;
+
+/**
+ * One console line correlated to a request. Recorded into the shared
+ * {@link TraceStore} from the console capture running on the request thread.
+ *
+ * @author kawasima
+ */
+public final class LogLine {
+    private final long timestampMillis;
+    private final String stream;
+    private final String text;
+
+    public LogLine(long timestampMillis, String stream, String text) {
+        this.timestampMillis = timestampMillis;
+        this.stream = stream;
+        this.text = text;
+    }
+
+    public long getTimestampMillis() { return timestampMillis; }
+    /** Source of the line, e.g. {@code OUT} or {@code ERR}. */
+    public String getStream() { return stream; }
+    public String getText() { return text; }
+}

--- a/waitt-api/src/main/java/net/unit8/waitt/api/observability/RequestTrace.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/observability/RequestTrace.java
@@ -1,0 +1,64 @@
+package net.unit8.waitt.api.observability;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Everything captured for one HTTP request, keyed by its OpenTelemetry trace id:
+ * the spans (HTTP + any nested), the SQL statements it ran, the console lines it
+ * emitted, and the exception that escaped it. Assembled in {@link TraceStore} and
+ * rendered by the admin dashboard as a correlated request-detail view.
+ *
+ * @author kawasima
+ */
+public final class RequestTrace {
+    private final String traceId;
+    private final long startEpochMillis;
+
+    private volatile String method;
+    private volatile String path;
+    private volatile int statusCode;
+    private volatile long durationMillis = -1;
+
+    private volatile String exceptionType;
+    private volatile String exceptionMessage;
+    private volatile String exceptionStack;
+
+    private final List<SpanRecord> spans = new CopyOnWriteArrayList<SpanRecord>();
+    private final List<SqlEvent> sqlEvents = new CopyOnWriteArrayList<SqlEvent>();
+    private final List<LogLine> logs = new CopyOnWriteArrayList<LogLine>();
+
+    public RequestTrace(String traceId, long startEpochMillis) {
+        this.traceId = traceId;
+        this.startEpochMillis = startEpochMillis;
+    }
+
+    public String getTraceId() { return traceId; }
+    public long getStartEpochMillis() { return startEpochMillis; }
+
+    public String getMethod() { return method; }
+    public void setMethod(String method) { this.method = method; }
+    public String getPath() { return path; }
+    public void setPath(String path) { this.path = path; }
+    public int getStatusCode() { return statusCode; }
+    public void setStatusCode(int statusCode) { this.statusCode = statusCode; }
+    public long getDurationMillis() { return durationMillis; }
+    public void setDurationMillis(long durationMillis) { this.durationMillis = durationMillis; }
+
+    public String getExceptionType() { return exceptionType; }
+    public String getExceptionMessage() { return exceptionMessage; }
+    public String getExceptionStack() { return exceptionStack; }
+    public void setException(String type, String message, String stack) {
+        this.exceptionType = type;
+        this.exceptionMessage = message;
+        this.exceptionStack = stack;
+    }
+
+    public void addSpan(SpanRecord span) { spans.add(span); }
+    public void addSqlEvent(SqlEvent event) { sqlEvents.add(event); }
+    public void addLog(LogLine line) { logs.add(line); }
+
+    public List<SpanRecord> getSpans() { return spans; }
+    public List<SqlEvent> getSqlEvents() { return sqlEvents; }
+    public List<LogLine> getLogs() { return logs; }
+}

--- a/waitt-api/src/main/java/net/unit8/waitt/api/observability/RequestTrace.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/observability/RequestTrace.java
@@ -1,7 +1,7 @@
 package net.unit8.waitt.api.observability;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Everything captured for one HTTP request, keyed by its OpenTelemetry trace id:
@@ -23,10 +23,15 @@ public final class RequestTrace {
     private volatile String exceptionType;
     private volatile String exceptionMessage;
     private volatile String exceptionStack;
+    private volatile String openerSpanId;
 
-    private final List<SpanRecord> spans = new CopyOnWriteArrayList<SpanRecord>();
-    private final List<SqlEvent> sqlEvents = new CopyOnWriteArrayList<SqlEvent>();
-    private final List<LogLine> logs = new CopyOnWriteArrayList<LogLine>();
+    // Single-writer high-frequency appends (all from the request thread); readers
+    // (the admin thread, at request end) get a synchronized snapshot. A plain
+    // synchronized ArrayList beats CopyOnWriteArrayList here, whose per-add full
+    // copy would be O(n^2) for a request that logs many lines.
+    private final List<SpanRecord> spans = new ArrayList<SpanRecord>();
+    private final List<SqlEvent> sqlEvents = new ArrayList<SqlEvent>();
+    private final List<LogLine> logs = new ArrayList<LogLine>();
 
     public RequestTrace(String traceId, long startEpochMillis) {
         this.traceId = traceId;
@@ -35,6 +40,22 @@ public final class RequestTrace {
 
     public String getTraceId() { return traceId; }
     public long getStartEpochMillis() { return startEpochMillis; }
+
+    /**
+     * The span that opened this trace (the first span seen for the trace id).
+     * The trace is finalized when this span ends, which is robust against a
+     * non-root HTTP span (ambient parent) and against nested spans.
+     */
+    public String getOpenerSpanId() { return openerSpanId; }
+
+    /** Claim this trace's opener slot; true only for the first caller. */
+    public synchronized boolean markOpener(String spanId) {
+        if (openerSpanId == null) {
+            openerSpanId = spanId;
+            return true;
+        }
+        return false;
+    }
 
     public String getMethod() { return method; }
     public void setMethod(String method) { this.method = method; }
@@ -54,11 +75,11 @@ public final class RequestTrace {
         this.exceptionStack = stack;
     }
 
-    public void addSpan(SpanRecord span) { spans.add(span); }
-    public void addSqlEvent(SqlEvent event) { sqlEvents.add(event); }
-    public void addLog(LogLine line) { logs.add(line); }
+    public void addSpan(SpanRecord span) { synchronized (spans) { spans.add(span); } }
+    public void addSqlEvent(SqlEvent event) { synchronized (sqlEvents) { sqlEvents.add(event); } }
+    public void addLog(LogLine line) { synchronized (logs) { logs.add(line); } }
 
-    public List<SpanRecord> getSpans() { return spans; }
-    public List<SqlEvent> getSqlEvents() { return sqlEvents; }
-    public List<LogLine> getLogs() { return logs; }
+    public List<SpanRecord> getSpans() { synchronized (spans) { return new ArrayList<SpanRecord>(spans); } }
+    public List<SqlEvent> getSqlEvents() { synchronized (sqlEvents) { return new ArrayList<SqlEvent>(sqlEvents); } }
+    public List<LogLine> getLogs() { synchronized (logs) { return new ArrayList<LogLine>(logs); } }
 }

--- a/waitt-api/src/main/java/net/unit8/waitt/api/observability/SpanRecord.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/observability/SpanRecord.java
@@ -1,0 +1,50 @@
+package net.unit8.waitt.api.observability;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A single span mapped from an OpenTelemetry span into a plain, ClassRealm-neutral
+ * form. Lives in {@code waitt-api} so the tracer realm (which produces it) and the
+ * admin realm (which renders it) share the same type without reflection.
+ *
+ * @author kawasima
+ */
+public final class SpanRecord {
+    private final String spanId;
+    private final String parentSpanId;
+    private final String name;
+    private final long startEpochNanos;
+    private final long endEpochNanos;
+    private final boolean error;
+    private final Map<String, String> attributes;
+
+    public SpanRecord(String spanId, String parentSpanId, String name,
+                      long startEpochNanos, long endEpochNanos, boolean error,
+                      Map<String, String> attributes) {
+        this.spanId = spanId;
+        this.parentSpanId = parentSpanId;
+        this.name = name;
+        this.startEpochNanos = startEpochNanos;
+        this.endEpochNanos = endEpochNanos;
+        this.error = error;
+        this.attributes = attributes == null
+                ? Collections.<String, String>emptyMap()
+                : Collections.unmodifiableMap(new LinkedHashMap<String, String>(attributes));
+    }
+
+    public String getSpanId() { return spanId; }
+    public String getParentSpanId() { return parentSpanId; }
+    public String getName() { return name; }
+    public long getStartEpochNanos() { return startEpochNanos; }
+    public long getEndEpochNanos() { return endEpochNanos; }
+    public long getDurationNanos() { return endEpochNanos - startEpochNanos; }
+    public boolean isError() { return error; }
+    public Map<String, String> getAttributes() { return attributes; }
+
+    /** True when this span carries database attributes (a SQL/JDBC span). */
+    public boolean isDatabase() {
+        return attributes.containsKey("db.statement") || attributes.containsKey("db.system");
+    }
+}

--- a/waitt-api/src/main/java/net/unit8/waitt/api/observability/SqlEvent.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/observability/SqlEvent.java
@@ -1,0 +1,35 @@
+package net.unit8.waitt.api.observability;
+
+/**
+ * One JDBC statement execution captured for a request. Recorded directly into the
+ * shared {@link TraceStore} by a DataSource/Connection proxy running in the webapp
+ * realm — a plain {@code waitt-api} call, no reflection.
+ *
+ * @author kawasima
+ */
+public final class SqlEvent {
+    private final long startEpochMillis;
+    private final long durationMillis;
+    private final String sql;
+    private final int rowCount;
+    private final boolean success;
+    private final String error;
+
+    public SqlEvent(long startEpochMillis, long durationMillis, String sql,
+                    int rowCount, boolean success, String error) {
+        this.startEpochMillis = startEpochMillis;
+        this.durationMillis = durationMillis;
+        this.sql = sql;
+        this.rowCount = rowCount;
+        this.success = success;
+        this.error = error;
+    }
+
+    public long getStartEpochMillis() { return startEpochMillis; }
+    public long getDurationMillis() { return durationMillis; }
+    public String getSql() { return sql; }
+    /** Affected/returned rows, or {@code -1} when unknown. */
+    public int getRowCount() { return rowCount; }
+    public boolean isSuccess() { return success; }
+    public String getError() { return error; }
+}

--- a/waitt-api/src/main/java/net/unit8/waitt/api/observability/TraceStore.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/observability/TraceStore.java
@@ -1,0 +1,157 @@
+package net.unit8.waitt.api.observability;
+
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+/**
+ * Process-wide correlation hub for the dashboard's request-detail view.
+ * <p>
+ * Because this class lives in {@code waitt-api} — the single realm shared by the
+ * webapp, tracer, and admin realms — its static singleton is genuinely one object
+ * across all of them, so producers and the reader share it with plain method calls
+ * (no reflection, no {@code System.getProperties()} handoff).
+ * <p>
+ * Spans arrive from the tracer realm (mapped from OpenTelemetry); SQL and log lines
+ * are recorded from the webapp/request thread and correlated to the in-flight trace
+ * via {@link #currentTraceId()} (a {@link ThreadLocal}). Completed traces are kept
+ * in a bounded ring, newest first.
+ *
+ * @author kawasima
+ */
+public final class TraceStore {
+    private static final TraceStore INSTANCE = new TraceStore();
+
+    public static TraceStore getInstance() { return INSTANCE; }
+
+    private volatile boolean enabled;
+    private volatile int capacity = 100;
+
+    private final Map<String, RequestTrace> active = new ConcurrentHashMap<String, RequestTrace>();
+    private final Deque<RequestTrace> completed = new ConcurrentLinkedDeque<RequestTrace>();
+    private final ThreadLocal<String> currentTraceId = new ThreadLocal<String>();
+    private volatile TraceListener listener;
+
+    private TraceStore() {}
+
+    /** Notified when a trace completes, so the dashboard can push it live. */
+    public interface TraceListener {
+        void onTraceCompleted(RequestTrace trace);
+    }
+
+    public void setListener(TraceListener listener) { this.listener = listener; }
+
+    /** Enabled by the admin feature when the dashboard is present; off by default. */
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+    public boolean isEnabled() { return enabled; }
+
+    public void setCapacity(int capacity) { if (capacity > 0) this.capacity = capacity; }
+
+    // --- trace assembly (driven by the tracer's span processor) ---
+
+    /** Start (or fetch) the in-flight trace for a root span. */
+    public RequestTrace beginTrace(String traceId, long startEpochMillis) {
+        if (!enabled || traceId == null) {
+            return null;
+        }
+        RequestTrace trace = active.get(traceId);
+        if (trace == null) {
+            trace = new RequestTrace(traceId, startEpochMillis);
+            RequestTrace existing = active.putIfAbsent(traceId, trace);
+            if (existing != null) {
+                trace = existing;
+            }
+        }
+        return trace;
+    }
+
+    public void addSpan(String traceId, SpanRecord span) {
+        if (!enabled || traceId == null) {
+            return;
+        }
+        RequestTrace trace = active.get(traceId);
+        if (trace != null) {
+            trace.addSpan(span);
+        }
+    }
+
+    /** Finalize the root span's trace and move it into the completed ring. */
+    public void completeTrace(String traceId) {
+        if (traceId == null) {
+            return;
+        }
+        RequestTrace trace = active.remove(traceId);
+        if (trace == null) {
+            return;
+        }
+        completed.addFirst(trace);
+        while (completed.size() > capacity) {
+            if (completed.pollLast() == null) {
+                break;
+            }
+        }
+        TraceListener l = listener;
+        if (l != null) {
+            try {
+                l.onTraceCompleted(trace);
+            } catch (RuntimeException ignored) {
+                // a listener error must not break span processing
+            }
+        }
+    }
+
+    // --- request-thread correlation (SQL, logs) ---
+
+    public void setCurrentTraceId(String traceId) { currentTraceId.set(traceId); }
+    public void clearCurrentTraceId() { currentTraceId.remove(); }
+    public String currentTraceId() { return currentTraceId.get(); }
+
+    public void recordSql(SqlEvent event) {
+        RequestTrace trace = currentActiveTrace();
+        if (trace != null) {
+            trace.addSqlEvent(event);
+        }
+    }
+
+    public void recordLog(LogLine line) {
+        RequestTrace trace = currentActiveTrace();
+        if (trace != null) {
+            trace.addLog(line);
+        }
+    }
+
+    private RequestTrace currentActiveTrace() {
+        if (!enabled) {
+            return null;
+        }
+        String traceId = currentTraceId.get();
+        return traceId == null ? null : active.get(traceId);
+    }
+
+    // --- read side (admin UI) ---
+
+    public List<RequestTrace> recentTraces() {
+        return new ArrayList<RequestTrace>(completed);
+    }
+
+    public RequestTrace getTrace(String traceId) {
+        if (traceId == null) {
+            return null;
+        }
+        RequestTrace trace = active.get(traceId);
+        if (trace != null) {
+            return trace;
+        }
+        for (RequestTrace t : completed) {
+            if (traceId.equals(t.getTraceId())) {
+                return t;
+            }
+        }
+        return null;
+    }
+
+    public int size() { return completed.size(); }
+}

--- a/waitt-api/src/main/java/net/unit8/waitt/api/observability/TraceStore.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/observability/TraceStore.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Process-wide correlation hub for the dashboard's request-detail view.
@@ -32,6 +33,7 @@ public final class TraceStore {
 
     private final Map<String, RequestTrace> active = new ConcurrentHashMap<String, RequestTrace>();
     private final Deque<RequestTrace> completed = new ConcurrentLinkedDeque<RequestTrace>();
+    private final AtomicInteger completedCount = new AtomicInteger(0);
     private final ThreadLocal<String> currentTraceId = new ThreadLocal<String>();
     private volatile TraceListener listener;
 
@@ -88,10 +90,13 @@ public final class TraceStore {
             return;
         }
         completed.addFirst(trace);
-        while (completed.size() > capacity) {
+        completedCount.incrementAndGet();
+        // O(1) trim: ConcurrentLinkedDeque.size() is O(n), so track the count.
+        while (completedCount.get() > capacity) {
             if (completed.pollLast() == null) {
                 break;
             }
+            completedCount.decrementAndGet();
         }
         TraceListener l = listener;
         if (l != null) {
@@ -153,12 +158,13 @@ public final class TraceStore {
         return null;
     }
 
-    public int size() { return completed.size(); }
+    public int size() { return completedCount.get(); }
 
     /** Drop all retained state (used on shutdown and by tests). */
     public void clear() {
         active.clear();
         completed.clear();
+        completedCount.set(0);
         currentTraceId.remove();
     }
 }

--- a/waitt-api/src/main/java/net/unit8/waitt/api/observability/TraceStore.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/observability/TraceStore.java
@@ -154,4 +154,11 @@ public final class TraceStore {
     }
 
     public int size() { return completed.size(); }
+
+    /** Drop all retained state (used on shutdown and by tests). */
+    public void clear() {
+        active.clear();
+        completed.clear();
+        currentTraceId.remove();
+    }
 }

--- a/waitt-api/src/test/java/net/unit8/waitt/api/observability/TraceStoreTest.java
+++ b/waitt-api/src/test/java/net/unit8/waitt/api/observability/TraceStoreTest.java
@@ -94,6 +94,17 @@ public class TraceStoreTest {
         assertEquals("t1", notified.get());
     }
 
+    @Test
+    public void onlyFirstMarkOpenerWins() {
+        RequestTrace t = store.beginTrace("t1", 1L);
+        assertTrue(t.markOpener("spanA"));
+        assertEquals("spanA", t.getOpenerSpanId());
+        // A later span (nested, or the HTTP span under an ambient parent) must not
+        // steal the opener slot — that keeps finalization tied to the right span.
+        assertFalse(t.markOpener("spanB"));
+        assertEquals("spanA", t.getOpenerSpanId());
+    }
+
     private static SpanRecord span(String id, String parent, String name) {
         return new SpanRecord(id, parent, name, 0L, 1_000_000L, false,
                 Collections.<String, String>emptyMap());

--- a/waitt-api/src/test/java/net/unit8/waitt/api/observability/TraceStoreTest.java
+++ b/waitt-api/src/test/java/net/unit8/waitt/api/observability/TraceStoreTest.java
@@ -1,0 +1,101 @@
+package net.unit8.waitt.api.observability;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.*;
+
+public class TraceStoreTest {
+
+    private final TraceStore store = TraceStore.getInstance();
+
+    @Before
+    public void setUp() {
+        store.clear();
+        store.setCapacity(100);
+        store.setListener(null);
+        store.setEnabled(true);
+    }
+
+    @After
+    public void tearDown() {
+        store.setEnabled(false);
+        store.setListener(null);
+        store.clear();
+        store.clearCurrentTraceId();
+    }
+
+    @Test
+    public void disabledStoreDoesNotBeginOrRecord() {
+        store.setEnabled(false);
+        assertNull(store.beginTrace("t1", 1000L));
+        store.setCurrentTraceId("t1");
+        store.recordSql(new SqlEvent(0, 1, "select 1", 1, true, null));
+        assertNull(store.getTrace("t1"));
+    }
+
+    @Test
+    public void beginAddSpanCompleteMovesToRing() {
+        store.beginTrace("t1", 1000L);
+        store.addSpan("t1", span("s1", null, "HTTP GET"));
+        store.completeTrace("t1");
+
+        assertEquals(1, store.recentTraces().size());
+        RequestTrace t = store.getTrace("t1");
+        assertNotNull(t);
+        assertEquals(1, t.getSpans().size());
+    }
+
+    @Test
+    public void currentTraceIdCorrelatesSqlAndLogs() {
+        store.beginTrace("t1", 1000L);
+        store.setCurrentTraceId("t1");
+        store.recordSql(new SqlEvent(0, 3, "select 1", 1, true, null));
+        store.recordLog(new LogLine(0, "OUT", "hello"));
+        store.clearCurrentTraceId();
+
+        RequestTrace t = store.getTrace("t1");
+        assertEquals(1, t.getSqlEvents().size());
+        assertEquals(1, t.getLogs().size());
+        // With no current trace bound, records are dropped.
+        store.recordSql(new SqlEvent(0, 1, "select 2", 0, true, null));
+        assertEquals(1, t.getSqlEvents().size());
+    }
+
+    @Test
+    public void capacityEvictsOldestCompletedTrace() {
+        store.setCapacity(2);
+        for (int i = 1; i <= 3; i++) {
+            store.beginTrace("t" + i, i);
+            store.completeTrace("t" + i);
+        }
+        assertEquals(2, store.recentTraces().size());
+        assertNull(store.getTrace("t1")); // evicted
+        assertNotNull(store.getTrace("t3"));
+        // recentTraces is newest-first.
+        assertEquals("t3", store.recentTraces().get(0).getTraceId());
+    }
+
+    @Test
+    public void listenerFiresOnComplete() {
+        final AtomicReference<String> notified = new AtomicReference<String>();
+        store.setListener(new TraceStore.TraceListener() {
+            @Override
+            public void onTraceCompleted(RequestTrace trace) {
+                notified.set(trace.getTraceId());
+            }
+        });
+        store.beginTrace("t1", 1000L);
+        store.completeTrace("t1");
+        assertEquals("t1", notified.get());
+    }
+
+    private static SpanRecord span(String id, String parent, String name) {
+        return new SpanRecord(id, parent, name, 0L, 1_000_000L, false,
+                Collections.<String, String>emptyMap());
+    }
+}

--- a/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/OtelTracingFilter.java
+++ b/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/OtelTracingFilter.java
@@ -62,12 +62,6 @@ public class OtelTracingFilter implements Filter {
 
             scope = otel.makeCurrent.invoke(span);
             chain.doFilter(request, response);
-
-            int statusCode = res.getStatus();
-            otel.spanSetAttributeLong.invoke(span, "http.response.status_code", (long) statusCode);
-            if (statusCode >= 500) {
-                otel.setStatus.invoke(span, otel.statusError);
-            }
         } catch (IOException | ServletException e) {
             recordError(span, e);
             throw e;
@@ -78,9 +72,22 @@ public class OtelTracingFilter implements Filter {
             recordError(span, e);
             throw new ServletException(e);
         } finally {
+            // Set status in finally so a thrown request still records its code
+            // (the success path would otherwise skip it).
+            recordStatus(span, res.getStatus());
             closeQuietly(scope);
             endQuietly(span);
         }
+    }
+
+    private void recordStatus(Object span, int statusCode) {
+        if (span == null || otel == null) return;
+        try {
+            otel.spanSetAttributeLong.invoke(span, "http.response.status_code", (long) statusCode);
+            if (statusCode >= 500) {
+                otel.setStatus.invoke(span, otel.statusError);
+            }
+        } catch (Exception ignored) {}
     }
 
     private void recordError(Object span, Exception e) {

--- a/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/TraceRetentionProcessor.java
+++ b/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/TraceRetentionProcessor.java
@@ -1,5 +1,6 @@
 package net.unit8.waitt.feature.tracer;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
@@ -22,10 +23,14 @@ import java.util.Map;
  * writes only {@code waitt-api} types, so the admin realm reads them with no
  * reflection.
  * <p>
- * On a root span's start it opens the request's trace and binds the trace id to
- * the current thread (via {@link TraceStore#setCurrentTraceId(String)}) so SQL and
- * console lines emitted on that thread correlate; on the root span's end it
- * finalizes the trace and clears the thread binding.
+ * The <em>first</em> span seen for a trace id opens the trace and binds that id to
+ * the current thread (so SQL and console lines emitted on that thread correlate);
+ * the trace is finalized when that same opener span ends. Keying on the opener
+ * span rather than on "is root" keeps this correct when the HTTP span has an
+ * ambient/incoming parent, and avoids a nested span finalizing the trace early.
+ * <p>
+ * Note: correlation is thread-bound, so it covers synchronous request handling;
+ * work dispatched to other threads (async servlets) is not correlated.
  *
  * @author kawasima
  */
@@ -38,9 +43,9 @@ public class TraceRetentionProcessor implements SpanProcessor {
 
     @Override
     public void onStart(Context parentContext, ReadWriteSpan span) {
-        if (isRoot(span.getParentSpanContext().getSpanId())) {
-            String traceId = span.getSpanContext().getTraceId();
-            store.beginTrace(traceId, System.currentTimeMillis());
+        String traceId = span.getSpanContext().getTraceId();
+        RequestTrace trace = store.beginTrace(traceId, System.currentTimeMillis());
+        if (trace != null && trace.markOpener(span.getSpanContext().getSpanId())) {
             store.setCurrentTraceId(traceId);
         }
     }
@@ -54,14 +59,16 @@ public class TraceRetentionProcessor implements SpanProcessor {
     public void onEnd(ReadableSpan span) {
         SpanData data = span.toSpanData();
         String traceId = data.getTraceId();
-        boolean root = isRoot(data.getParentSpanId());
+        store.addSpan(traceId, toRecord(data));
 
-        store.addSpan(traceId, toRecord(data, root));
-
-        if (root) {
-            finalizeTrace(traceId, data);
-            store.completeTrace(traceId);
-            store.clearCurrentTraceId();
+        RequestTrace trace = store.getTrace(traceId);
+        if (trace != null && data.getSpanId().equals(trace.getOpenerSpanId())) {
+            try {
+                finalizeTrace(trace, data);
+            } finally {
+                store.completeTrace(traceId);
+                store.clearCurrentTraceId();
+            }
         }
     }
 
@@ -74,18 +81,18 @@ public class TraceRetentionProcessor implements SpanProcessor {
         return parentSpanId == null || SpanId.getInvalid().equals(parentSpanId);
     }
 
-    private SpanRecord toRecord(SpanData data, boolean root) {
+    private SpanRecord toRecord(SpanData data) {
         final Map<String, String> attrs = new LinkedHashMap<String, String>();
-        data.getAttributes().forEach(new java.util.function.BiConsumer<io.opentelemetry.api.common.AttributeKey<?>, Object>() {
+        data.getAttributes().forEach(new java.util.function.BiConsumer<AttributeKey<?>, Object>() {
             @Override
-            public void accept(io.opentelemetry.api.common.AttributeKey<?> key, Object value) {
+            public void accept(AttributeKey<?> key, Object value) {
                 attrs.put(key.getKey(), String.valueOf(value));
             }
         });
         boolean error = data.getStatus().getStatusCode() == StatusData.error().getStatusCode();
         return new SpanRecord(
                 data.getSpanId(),
-                root ? null : data.getParentSpanId(),
+                isRoot(data.getParentSpanId()) ? null : data.getParentSpanId(),
                 data.getName(),
                 data.getStartEpochNanos(),
                 data.getEndEpochNanos(),
@@ -93,20 +100,12 @@ public class TraceRetentionProcessor implements SpanProcessor {
                 attrs);
     }
 
-    private void finalizeTrace(String traceId, SpanData data) {
-        RequestTrace trace = store.getTrace(traceId);
-        if (trace == null) {
-            return;
-        }
-        trace.setMethod(attr(data, "http.request.method"));
-        trace.setPath(attr(data, "url.path"));
-        String status = attr(data, "http.response.status_code");
+    private void finalizeTrace(RequestTrace trace, SpanData data) {
+        trace.setMethod(stringAttr(data, "http.request.method"));
+        trace.setPath(stringAttr(data, "url.path"));
+        Long status = data.getAttributes().get(AttributeKey.longKey("http.response.status_code"));
         if (status != null) {
-            try {
-                trace.setStatusCode((int) Double.parseDouble(status));
-            } catch (NumberFormatException ignored) {
-                // leave status unset
-            }
+            trace.setStatusCode(status.intValue());
         }
         trace.setDurationMillis((data.getEndEpochNanos() - data.getStartEpochNanos()) / 1_000_000L);
         extractException(trace, data);
@@ -116,42 +115,21 @@ public class TraceRetentionProcessor implements SpanProcessor {
         for (EventData event : data.getEvents()) {
             if ("exception".equals(event.getName())) {
                 trace.setException(
-                        stringAttr(event, "exception.type"),
-                        stringAttr(event, "exception.message"),
-                        stringAttr(event, "exception.stacktrace"));
+                        eventAttr(event, "exception.type"),
+                        eventAttr(event, "exception.message"),
+                        eventAttr(event, "exception.stacktrace"));
                 return;
             }
         }
     }
 
-    private static String attr(SpanData data, String key) {
-        Object v = data.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey(key));
-        if (v != null) {
-            return String.valueOf(v);
-        }
-        // status_code is a long attribute; fall back to a generic scan.
-        final String[] found = new String[1];
-        data.getAttributes().forEach(new java.util.function.BiConsumer<io.opentelemetry.api.common.AttributeKey<?>, Object>() {
-            @Override
-            public void accept(io.opentelemetry.api.common.AttributeKey<?> k, Object value) {
-                if (k.getKey().equals(key)) {
-                    found[0] = String.valueOf(value);
-                }
-            }
-        });
-        return found[0];
+    private static String stringAttr(SpanData data, String key) {
+        Object v = data.getAttributes().get(AttributeKey.stringKey(key));
+        return v == null ? null : String.valueOf(v);
     }
 
-    private static String stringAttr(EventData event, String key) {
-        final String[] found = new String[1];
-        event.getAttributes().forEach(new java.util.function.BiConsumer<io.opentelemetry.api.common.AttributeKey<?>, Object>() {
-            @Override
-            public void accept(io.opentelemetry.api.common.AttributeKey<?> k, Object value) {
-                if (k.getKey().equals(key)) {
-                    found[0] = String.valueOf(value);
-                }
-            }
-        });
-        return found[0];
+    private static String eventAttr(EventData event, String key) {
+        Object v = event.getAttributes().get(AttributeKey.stringKey(key));
+        return v == null ? null : String.valueOf(v);
     }
 }

--- a/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/TraceRetentionProcessor.java
+++ b/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/TraceRetentionProcessor.java
@@ -1,0 +1,157 @@
+package net.unit8.waitt.feature.tracer;
+
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import io.opentelemetry.sdk.trace.data.EventData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import net.unit8.waitt.api.observability.RequestTrace;
+import net.unit8.waitt.api.observability.SpanRecord;
+import net.unit8.waitt.api.observability.TraceStore;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Retains OpenTelemetry spans in the shared {@link TraceStore} for the dashboard's
+ * request-detail view, mapping each span into the ClassRealm-neutral
+ * {@link SpanRecord}. Runs in the tracer realm (which owns the OTel classes) and
+ * writes only {@code waitt-api} types, so the admin realm reads them with no
+ * reflection.
+ * <p>
+ * On a root span's start it opens the request's trace and binds the trace id to
+ * the current thread (via {@link TraceStore#setCurrentTraceId(String)}) so SQL and
+ * console lines emitted on that thread correlate; on the root span's end it
+ * finalizes the trace and clears the thread binding.
+ *
+ * @author kawasima
+ */
+public class TraceRetentionProcessor implements SpanProcessor {
+    private final TraceStore store;
+
+    public TraceRetentionProcessor(TraceStore store) {
+        this.store = store;
+    }
+
+    @Override
+    public void onStart(Context parentContext, ReadWriteSpan span) {
+        if (isRoot(span.getParentSpanContext().getSpanId())) {
+            String traceId = span.getSpanContext().getTraceId();
+            store.beginTrace(traceId, System.currentTimeMillis());
+            store.setCurrentTraceId(traceId);
+        }
+    }
+
+    @Override
+    public boolean isStartRequired() {
+        return true;
+    }
+
+    @Override
+    public void onEnd(ReadableSpan span) {
+        SpanData data = span.toSpanData();
+        String traceId = data.getTraceId();
+        boolean root = isRoot(data.getParentSpanId());
+
+        store.addSpan(traceId, toRecord(data, root));
+
+        if (root) {
+            finalizeTrace(traceId, data);
+            store.completeTrace(traceId);
+            store.clearCurrentTraceId();
+        }
+    }
+
+    @Override
+    public boolean isEndRequired() {
+        return true;
+    }
+
+    private static boolean isRoot(String parentSpanId) {
+        return parentSpanId == null || SpanId.getInvalid().equals(parentSpanId);
+    }
+
+    private SpanRecord toRecord(SpanData data, boolean root) {
+        final Map<String, String> attrs = new LinkedHashMap<String, String>();
+        data.getAttributes().forEach(new java.util.function.BiConsumer<io.opentelemetry.api.common.AttributeKey<?>, Object>() {
+            @Override
+            public void accept(io.opentelemetry.api.common.AttributeKey<?> key, Object value) {
+                attrs.put(key.getKey(), String.valueOf(value));
+            }
+        });
+        boolean error = data.getStatus().getStatusCode() == StatusData.error().getStatusCode();
+        return new SpanRecord(
+                data.getSpanId(),
+                root ? null : data.getParentSpanId(),
+                data.getName(),
+                data.getStartEpochNanos(),
+                data.getEndEpochNanos(),
+                error,
+                attrs);
+    }
+
+    private void finalizeTrace(String traceId, SpanData data) {
+        RequestTrace trace = store.getTrace(traceId);
+        if (trace == null) {
+            return;
+        }
+        trace.setMethod(attr(data, "http.request.method"));
+        trace.setPath(attr(data, "url.path"));
+        String status = attr(data, "http.response.status_code");
+        if (status != null) {
+            try {
+                trace.setStatusCode((int) Double.parseDouble(status));
+            } catch (NumberFormatException ignored) {
+                // leave status unset
+            }
+        }
+        trace.setDurationMillis((data.getEndEpochNanos() - data.getStartEpochNanos()) / 1_000_000L);
+        extractException(trace, data);
+    }
+
+    private void extractException(RequestTrace trace, SpanData data) {
+        for (EventData event : data.getEvents()) {
+            if ("exception".equals(event.getName())) {
+                trace.setException(
+                        stringAttr(event, "exception.type"),
+                        stringAttr(event, "exception.message"),
+                        stringAttr(event, "exception.stacktrace"));
+                return;
+            }
+        }
+    }
+
+    private static String attr(SpanData data, String key) {
+        Object v = data.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey(key));
+        if (v != null) {
+            return String.valueOf(v);
+        }
+        // status_code is a long attribute; fall back to a generic scan.
+        final String[] found = new String[1];
+        data.getAttributes().forEach(new java.util.function.BiConsumer<io.opentelemetry.api.common.AttributeKey<?>, Object>() {
+            @Override
+            public void accept(io.opentelemetry.api.common.AttributeKey<?> k, Object value) {
+                if (k.getKey().equals(key)) {
+                    found[0] = String.valueOf(value);
+                }
+            }
+        });
+        return found[0];
+    }
+
+    private static String stringAttr(EventData event, String key) {
+        final String[] found = new String[1];
+        event.getAttributes().forEach(new java.util.function.BiConsumer<io.opentelemetry.api.common.AttributeKey<?>, Object>() {
+            @Override
+            public void accept(io.opentelemetry.api.common.AttributeKey<?> k, Object value) {
+                if (k.getKey().equals(key)) {
+                    found[0] = String.valueOf(value);
+                }
+            }
+        });
+        return found[0];
+    }
+}

--- a/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/TracerLifecycle.java
+++ b/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/TracerLifecycle.java
@@ -7,6 +7,7 @@ import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import net.unit8.waitt.api.ConfigurableFeature;
 import net.unit8.waitt.api.EmbeddedServer;
@@ -32,6 +33,7 @@ public class TracerLifecycle implements ServerMonitor, ConfigurableFeature {
 
     private OpenTelemetrySdk sdk;
     private String endpoint = DEFAULT_ENDPOINT;
+    private boolean endpointConfigured = false;
     private String serviceName = "waitt-app";
     private int retentionSize = 100;
 
@@ -47,6 +49,7 @@ public class TracerLifecycle implements ServerMonitor, ConfigurableFeature {
                 if (featureConfig != null) {
                     if (featureConfig.containsKey("otel.endpoint")) {
                         endpoint = featureConfig.get("otel.endpoint");
+                        endpointConfigured = true;
                     }
                     if (featureConfig.containsKey("otel.service.name")) {
                         serviceName = featureConfig.get("otel.service.name");
@@ -72,30 +75,38 @@ public class TracerLifecycle implements ServerMonitor, ConfigurableFeature {
                     ))
             );
 
-            String tracesEndpoint = endpoint.contains("/v1/traces") ? endpoint
-                    : endpoint.endsWith("/") ? endpoint + "v1/traces"
-                    : endpoint + "/v1/traces";
-            OtlpHttpSpanExporter spanExporter = OtlpHttpSpanExporter.builder()
-                    .setEndpoint(tracesEndpoint)
-                    .build();
-
             TraceStore store = TraceStore.getInstance();
             store.setCapacity(retentionSize);
             store.setEnabled(true);
 
-            SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
-                    .addSpanProcessor(BatchSpanProcessor.builder(spanExporter).build())
+            SdkTracerProviderBuilder tracerProviderBuilder = SdkTracerProvider.builder()
                     .addSpanProcessor(new TraceRetentionProcessor(store))
-                    .setResource(resource)
-                    .build();
+                    .setResource(resource);
+
+            // The in-process TraceStore already powers the built-in Traces view, so the
+            // OTLP exporter is opt-in: register it only when an endpoint was explicitly
+            // configured. Otherwise a missing collector would spam connection errors.
+            if (endpointConfigured) {
+                String tracesEndpoint = endpoint.contains("/v1/traces") ? endpoint
+                        : endpoint.endsWith("/") ? endpoint + "v1/traces"
+                        : endpoint + "/v1/traces";
+                OtlpHttpSpanExporter spanExporter = OtlpHttpSpanExporter.builder()
+                        .setEndpoint(tracesEndpoint)
+                        .build();
+                tracerProviderBuilder.addSpanProcessor(BatchSpanProcessor.builder(spanExporter).build());
+            }
 
             sdk = OpenTelemetrySdk.builder()
-                    .setTracerProvider(tracerProvider)
+                    .setTracerProvider(tracerProviderBuilder.build())
                     .build();
 
             Tracer tracer = sdk.getTracer("waitt-tracer");
             System.getProperties().put(TRACER_PROPERTY_KEY, tracer);
-            LOG.info("OpenTelemetry tracer initialized (endpoint=" + endpoint + ", service=" + serviceName + ")");
+            if (endpointConfigured) {
+                LOG.info("OpenTelemetry tracer initialized (OTLP export -> " + endpoint + ", service=" + serviceName + ")");
+            } else {
+                LOG.info("OpenTelemetry tracer initialized (in-process TraceStore only, service=" + serviceName + ")");
+            }
         } catch (Exception e) {
             LOG.log(Level.WARNING, "Failed to initialize OpenTelemetry tracer", e);
         }

--- a/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/TracerLifecycle.java
+++ b/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/TracerLifecycle.java
@@ -109,7 +109,9 @@ public class TracerLifecycle implements ServerMonitor, ConfigurableFeature {
     @Override
     public void stop() {
         System.getProperties().remove(TRACER_PROPERTY_KEY);
-        TraceStore.getInstance().setEnabled(false);
+        TraceStore store = TraceStore.getInstance();
+        store.setEnabled(false);
+        store.clear();
         if (sdk != null) {
             sdk.close();
             LOG.info("OpenTelemetry tracer shut down.");

--- a/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/TracerLifecycle.java
+++ b/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/TracerLifecycle.java
@@ -13,6 +13,7 @@ import net.unit8.waitt.api.EmbeddedServer;
 import net.unit8.waitt.api.ServerMonitor;
 import net.unit8.waitt.api.configuration.Feature;
 import net.unit8.waitt.api.configuration.WebappConfiguration;
+import net.unit8.waitt.api.observability.TraceStore;
 
 import java.util.Map;
 import java.util.logging.Level;
@@ -32,6 +33,7 @@ public class TracerLifecycle implements ServerMonitor, ConfigurableFeature {
     private OpenTelemetrySdk sdk;
     private String endpoint = DEFAULT_ENDPOINT;
     private String serviceName = "waitt-app";
+    private int retentionSize = 100;
 
     @Override
     public void config(WebappConfiguration config) {
@@ -48,6 +50,13 @@ public class TracerLifecycle implements ServerMonitor, ConfigurableFeature {
                     }
                     if (featureConfig.containsKey("otel.service.name")) {
                         serviceName = featureConfig.get("otel.service.name");
+                    }
+                    if (featureConfig.containsKey("trace.retention.size")) {
+                        try {
+                            retentionSize = Integer.parseInt(featureConfig.get("trace.retention.size"));
+                        } catch (NumberFormatException e) {
+                            LOG.warning("Invalid trace.retention.size: " + featureConfig.get("trace.retention.size"));
+                        }
                     }
                 }
             }
@@ -70,8 +79,13 @@ public class TracerLifecycle implements ServerMonitor, ConfigurableFeature {
                     .setEndpoint(tracesEndpoint)
                     .build();
 
+            TraceStore store = TraceStore.getInstance();
+            store.setCapacity(retentionSize);
+            store.setEnabled(true);
+
             SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
                     .addSpanProcessor(BatchSpanProcessor.builder(spanExporter).build())
+                    .addSpanProcessor(new TraceRetentionProcessor(store))
                     .setResource(resource)
                     .build();
 
@@ -95,6 +109,7 @@ public class TracerLifecycle implements ServerMonitor, ConfigurableFeature {
     @Override
     public void stop() {
         System.getProperties().remove(TRACER_PROPERTY_KEY);
+        TraceStore.getInstance().setEnabled(false);
         if (sdk != null) {
             sdk.close();
             LOG.info("OpenTelemetry tracer shut down.");


### PR DESCRIPTION
First step of the correlated dev-observability direction ("Telescope for Java"): the admin dashboard gains a **Traces** view — a per-request span waterfall with the correlated logs and exception — reusing the OpenTelemetry spans `waitt-tracer` already produces, with no external collector.

## Architecture (ClassRealm-clean)

`waitt-api` loads once in the shared parent realm, so plain classes added there are the *same* type in the webapp, tracer, and admin realms. The design uses that instead of reflection or `System.getProperties()` handoffs:

- **waitt-api** — realm-neutral model (`RequestTrace` / `SpanRecord` / `SqlEvent` / `LogLine`) and a `TraceStore` singleton (ring buffer + `ThreadLocal` current-trace).
- **waitt-tracer** — `TraceRetentionProcessor` (an OTel `SpanProcessor`) retains spans in the store, mapping `SpanData` → `waitt-api` `SpanRecord` *inside the tracer realm*, so the admin realm reads only `waitt-api` types (no reflection). It binds the trace id to the request thread on the root span so logs/SQL correlate, and finalizes method/path/status/exception on root end. `trace.retention.size` configurable.
- **waitt-admin** — `/traces` (list) and `/traces/{id}` (detail) endpoints; a **Traces** page with a span waterfall + correlated logs/exception; live `trace` SSE events via a `TraceStore` listener. `ConsoleCapture` now correlates console lines to the current trace.

Waterfall offsets are computed server-side as relative longs (absolute epoch nanos exceed JS's safe-integer range).

## Scope

This is **SP1**. SQL/JDBC instrumentation (SP2) is deferred — the `SqlEvent` plumbing and an empty-state ("requires waitt-jdbc") are in place, but nothing produces SQL yet. The injection mechanism has real framework-coverage tradeoffs and gets its own PR.

**Limitation:** the Traces view requires `waitt-tracer` (OpenTelemetry), so it is jakarta-only (Tomcat 10/11, Jetty 12).

## Tests & verification

- `TraceStoreTest` (5): enable gating, begin/addSpan/complete ring eviction, current-trace SQL/log correlation, completion listener. Full suite green (waitt-api 5, waitt-admin 20).
- Verified end-to-end against `examples/spring-boot`: `/traces` list + `/traces/{id}` detail render the HTTP span with attributes; live `trace` SSE events flow (200/200/404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)