### PR TITLE
Release v1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Add plugin to your pom.xml
 <plugin>
   <groupId>net.unit8.waitt</groupId>
   <artifactId>waitt-maven-plugin</artifactId>
-  <version>1.5.0</version>
+  <version>1.5.1-SNAPSHOT</version>
   <configuration>
     <servers>
       <server>
         <groupId>net.unit8.waitt.server</groupId>
         <artifactId>waitt-tomcat9</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1-SNAPSHOT</version>
       </server>
     </servers>
   </configuration>
@@ -96,7 +96,7 @@ Choose a server based on the Servlet API version your application uses.
   <server>
     <groupId>net.unit8.waitt.server</groupId>
     <artifactId>waitt-tomcat9</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1-SNAPSHOT</version>
   </server>
 ```
 
@@ -106,7 +106,7 @@ Choose a server based on the Servlet API version your application uses.
   <server>
     <groupId>net.unit8.waitt.server</groupId>
     <artifactId>waitt-tomcat10</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1-SNAPSHOT</version>
   </server>
 ```
 
@@ -116,7 +116,7 @@ Choose a server based on the Servlet API version your application uses.
   <server>
     <groupId>net.unit8.waitt.server</groupId>
     <artifactId>waitt-tomcat11</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1-SNAPSHOT</version>
   </server>
 ```
 
@@ -126,7 +126,7 @@ Choose a server based on the Servlet API version your application uses.
   <server>
     <groupId>net.unit8.waitt.server</groupId>
     <artifactId>waitt-jetty12</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1-SNAPSHOT</version>
   </server>
 ```
 
@@ -142,7 +142,7 @@ When you access to `/_coverage/`, you can see the coverages of your code.
   <feature>
     <groupId>net.unit8.waitt.feature</groupId>
     <artifactId>waitt-jacoco</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1-SNAPSHOT</version>
   </feature>
 ```
 
@@ -155,7 +155,7 @@ Access `http://localhost:1192/` to view the dashboard (application info, JVM met
   <feature>
     <groupId>net.unit8.waitt.feature</groupId>
     <artifactId>waitt-admin</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1-SNAPSHOT</version>
   </feature>
 ```
 
@@ -168,7 +168,7 @@ Note: waitt-tracer uses the Jakarta Servlet API, so it is only compatible with T
   <feature>
     <groupId>net.unit8.waitt.feature</groupId>
     <artifactId>waitt-tracer</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1-SNAPSHOT</version>
     <configuration>
       <elasticsearch.url>http://[es host]:9200</elasticsearch.url>
     </configuration>
@@ -184,7 +184,7 @@ No manual reload trigger needed — just run `mvn compile` in another terminal.
   <feature>
     <groupId>net.unit8.waitt.feature</groupId>
     <artifactId>waitt-devtools</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1-SNAPSHOT</version>
   </feature>
 ```
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,9 @@ request detail — a span waterfall plus the logs and exception for that request
 with no external stack required.
 
 Note: waitt-tracer uses the Jakarta Servlet API, so the Traces view is only
-available on Tomcat 10/11 and Jetty 12.
+available on Tomcat 10/11 and Jetty 12. Correlation is thread-bound, so it covers
+synchronous request handling; work an app dispatches to other threads (async
+servlets) is not correlated to its request.
 
 ```xml
   <feature>

--- a/README.md
+++ b/README.md
@@ -151,11 +151,30 @@ When you access to `/_coverage/`, you can see the coverages of your code.
 The admin server provides a built-in dashboard UI and monitoring API.
 Access `http://localhost:1192/` to view the dashboard (application info, JVM metrics, thread/heap dumps, loggers, dependencies, etc.).
 
+It streams live over Server-Sent Events (`/stream`), so the dashboard needs no external
+observability stack to watch your app during development:
+
+- **Request Log** and **Logs** pages tail in real time as requests arrive and the app writes to stdout/stderr.
+- **Metrics** page exposes a Prometheus scrape endpoint (`/prometheus`, including `http.server.requests`) you can point Prometheus/Grafana at.
+
 ```xml
   <feature>
     <groupId>net.unit8.waitt.feature</groupId>
     <artifactId>waitt-admin</artifactId>
     <version>1.5.1-SNAPSHOT</version>
+  </feature>
+```
+
+The log buffer size is configurable (default 1000 lines):
+
+```xml
+  <feature>
+    <groupId>net.unit8.waitt.feature</groupId>
+    <artifactId>waitt-admin</artifactId>
+    <version>1.5.1-SNAPSHOT</version>
+    <configuration>
+      <log.buffer.size>2000</log.buffer.size>
+    </configuration>
   </feature>
 ```
 

--- a/README.md
+++ b/README.md
@@ -180,11 +180,13 @@ The log buffer size is configurable (default 1000 lines):
 
 ### Tracer
 
-`waitt-tracer` creates an OpenTelemetry span for each HTTP request. Spans are both
-exported over OTLP (to an external collector such as Jaeger) **and** retained
-in-process so the admin dashboard's **Traces** page can show a correlated
-request detail — a span waterfall plus the logs and exception for that request —
-with no external stack required.
+`waitt-tracer` creates an OpenTelemetry span for each HTTP request. Spans are
+always retained in-process so the admin dashboard's **Traces** page can show a
+correlated request detail — a span waterfall plus the logs and exception for that
+request — with no external stack required. OTLP export to an external collector
+(such as Jaeger) is opt-in: it happens only when you set `otel.endpoint`. Leave it
+unset and the tracer runs purely in-process, so no collector is required and no
+connection errors are logged.
 
 Note: waitt-tracer uses the Jakarta Servlet API, so the Traces view is only
 available on Tomcat 10/11 and Jetty 12. Correlation is thread-bound, so it covers
@@ -197,7 +199,7 @@ servlets) is not correlated to its request.
     <artifactId>waitt-tracer</artifactId>
     <version>1.5.1-SNAPSHOT</version>
     <configuration>
-      <!-- OTLP/HTTP collector endpoint (default http://localhost:4318) -->
+      <!-- Optional: OTLP/HTTP collector endpoint. Omit to run in-process only. -->
       <otel.endpoint>http://localhost:4318</otel.endpoint>
       <!-- number of recent traces kept for the dashboard (default 100) -->
       <trace.retention.size>100</trace.retention.size>

--- a/README.md
+++ b/README.md
@@ -180,8 +180,14 @@ The log buffer size is configurable (default 1000 lines):
 
 ### Tracer
 
-You can show and search HTTP request/response logs at development in Kibana.
-Note: waitt-tracer uses the Jakarta Servlet API, so it is only compatible with Tomcat 10/11 and Jetty 12.
+`waitt-tracer` creates an OpenTelemetry span for each HTTP request. Spans are both
+exported over OTLP (to an external collector such as Jaeger) **and** retained
+in-process so the admin dashboard's **Traces** page can show a correlated
+request detail — a span waterfall plus the logs and exception for that request —
+with no external stack required.
+
+Note: waitt-tracer uses the Jakarta Servlet API, so the Traces view is only
+available on Tomcat 10/11 and Jetty 12.
 
 ```xml
   <feature>
@@ -189,10 +195,15 @@ Note: waitt-tracer uses the Jakarta Servlet API, so it is only compatible with T
     <artifactId>waitt-tracer</artifactId>
     <version>1.5.1-SNAPSHOT</version>
     <configuration>
-      <elasticsearch.url>http://[es host]:9200</elasticsearch.url>
+      <!-- OTLP/HTTP collector endpoint (default http://localhost:4318) -->
+      <otel.endpoint>http://localhost:4318</otel.endpoint>
+      <!-- number of recent traces kept for the dashboard (default 100) -->
+      <trace.retention.size>100</trace.retention.size>
     </configuration>
   </feature>
 ```
+
+Pair it with `waitt-admin` to view the Traces page at `http://localhost:1192/#traces`.
 
 ### DevTools (Auto-Reload)
 

--- a/examples/nablarch/pom.xml
+++ b/examples/nablarch/pom.xml
@@ -15,7 +15,7 @@
     <packaging>war</packaging>
 
     <properties>
-        <waitt.version>1.5.0</waitt.version>
+        <waitt.version>1.5.1-SNAPSHOT</waitt.version>
         <scheme>画面オンライン</scheme>
         <!-- 環境ごとのリソースディレクトリ(プロファイルにより切り替わる) -->
         <env.resources>${project.basedir}/src/env/${env.dir}/resources</env.resources>

--- a/examples/sa-struts/pom.xml
+++ b/examples/sa-struts/pom.xml
@@ -7,7 +7,7 @@
     <packaging>war</packaging>
     <description/>
     <properties>
-        <waitt.version>1.5.0</waitt.version>
+        <waitt.version>1.5.1-SNAPSHOT</waitt.version>
     </properties>
     <build>
         <finalName>${artifactId}</finalName>

--- a/examples/spring-boot/pom.xml
+++ b/examples/spring-boot/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.3</version>
+        <version>3.5.13</version>
     </parent>
     <groupId>net.unit8.waitt.example</groupId>
     <artifactId>spring-boot-example</artifactId>

--- a/examples/spring-boot/pom.xml
+++ b/examples/spring-boot/pom.xml
@@ -16,7 +16,7 @@
     <url>https://github.com/kawasima/waitt</url>
 
     <properties>
-        <waitt.version>1.5.0</waitt.version>
+        <waitt.version>1.5.1-SNAPSHOT</waitt.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>17</java.version>
     </properties>

--- a/examples/struts2/pom.xml
+++ b/examples/struts2/pom.xml
@@ -8,7 +8,7 @@
     <name>struts2-example</name>
 
     <properties>
-        <waitt.version>1.5.0</waitt.version>
+        <waitt.version>1.5.1-SNAPSHOT</waitt.version>
         <struts2.version>6.8.0</struts2.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>net.unit8.waitt</groupId>
     <artifactId>waitt-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>waitt-parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -40,13 +40,6 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.14.0</version>
                     <configuration>
-                        <annotationProcessorPaths>
-                            <path>
-                                <groupId>org.projectlombok</groupId>
-                                <artifactId>lombok</artifactId>
-                                <version>1.18.42</version>
-                            </path>
-                        </annotationProcessorPaths>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -151,14 +144,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok</artifactId>
-                <version>1.18.42</version>
-            </dependency>
-            <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-classworlds</artifactId>
-                <version>2.6.0</version>
+                <version>2.10.0</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
@@ -168,7 +156,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>4.5.0</version>
+                <version>4.11.0</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -178,7 +166,7 @@
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <version>2.11.0</version>
+                <version>2.13.2</version>
             </dependency>
             <dependency>
                 <groupId>org.gridkit.jvmtool</groupId>
@@ -188,7 +176,7 @@
             <dependency>
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-bom</artifactId>
-                <version>1.46.0</version>
+                <version>1.61.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/waitt-admin/pom.xml
+++ b/waitt-admin/pom.xml
@@ -40,11 +40,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
         </dependency>

--- a/waitt-admin/pom.xml
+++ b/waitt-admin/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>net.unit8.waitt</groupId>
         <artifactId>waitt-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/AdminMetrics.java
+++ b/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/AdminMetrics.java
@@ -1,0 +1,56 @@
+package net.unit8.waitt.feature.admin;
+
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+
+import java.io.Closeable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Owns the shared Micrometer registry for the admin server.
+ * <p>
+ * JVM metrics (GC/memory/thread) are bound once, and HTTP request metrics are
+ * recorded per request through {@link #recordHttpRequest(String, int, long)}.
+ * Both the Prometheus scrape endpoint and the request listener use this single
+ * registry, so a scrape reflects live traffic.
+ *
+ * @author kawasima
+ */
+public class AdminMetrics implements Closeable {
+    private final PrometheusMeterRegistry registry;
+    private final JvmGcMetrics gcMetrics;
+
+    public AdminMetrics() {
+        registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        gcMetrics = new JvmGcMetrics();
+        gcMetrics.bindTo(registry);
+        new JvmMemoryMetrics().bindTo(registry);
+        new JvmThreadMetrics().bindTo(registry);
+    }
+
+    /**
+     * Record one HTTP request. The path is intentionally not used as a tag to
+     * avoid unbounded cardinality over a long-running development session.
+     */
+    public void recordHttpRequest(String method, int status, long durationMs) {
+        Timer.builder("http.server.requests")
+                .tag("method", method == null ? "UNKNOWN" : method)
+                .tag("status", Integer.toString(status))
+                .register(registry)
+                .record(durationMs, TimeUnit.MILLISECONDS);
+    }
+
+    public String scrape() {
+        return registry.scrape();
+    }
+
+    @Override
+    public void close() {
+        gcMetrics.close();
+        registry.close();
+    }
+}

--- a/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/AdminMetrics.java
+++ b/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/AdminMetrics.java
@@ -8,6 +8,7 @@ import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 
 import java.io.Closeable;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -38,7 +39,7 @@ public class AdminMetrics implements Closeable {
      */
     public void recordHttpRequest(String method, int status, long durationMs) {
         Timer.builder("http.server.requests")
-                .tag("method", method == null ? "UNKNOWN" : method)
+                .tag("method", method == null ? "UNKNOWN" : method.toUpperCase(Locale.ROOT))
                 .tag("status", Integer.toString(status))
                 .register(registry)
                 .record(durationMs, TimeUnit.MILLISECONDS);

--- a/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/AdminServer.java
+++ b/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/AdminServer.java
@@ -6,6 +6,8 @@ import net.unit8.waitt.api.EmbeddedServer;
 import net.unit8.waitt.api.ServerMonitor;
 import net.unit8.waitt.api.configuration.Feature;
 import net.unit8.waitt.api.configuration.WebappConfiguration;
+import net.unit8.waitt.api.observability.RequestTrace;
+import net.unit8.waitt.api.observability.TraceStore;
 import net.unit8.waitt.feature.admin.json.JSONObject;
 import net.unit8.waitt.feature.admin.routes.*;
 
@@ -100,6 +102,7 @@ public class AdminServer implements ServerMonitor, ConfigurableFeature {
         app.addRoutes(new PrometheusAction(metrics));
         app.addRoutes(new StreamAction(broadcaster));
         app.addRoutes(new LogsAction(logBuffer));
+        app.addRoutes(new TracesAction());
 
         rrdPath = "target/rrd/" + config.getApplicationName() + ".rrd";
     }
@@ -118,6 +121,15 @@ public class AdminServer implements ServerMonitor, ConfigurableFeature {
                     metrics.recordHttpRequest(method, status, durationMs);
                 } catch (RuntimeException e) {
                     LOG.log(Level.FINE, "Failed to record request telemetry", e);
+                }
+            }
+        });
+        // Push completed traces to the dashboard live.
+        TraceStore.getInstance().setListener(new TraceStore.TraceListener() {
+            @Override
+            public void onTraceCompleted(RequestTrace trace) {
+                if (broadcaster.hasSubscribers()) {
+                    broadcaster.publish("trace", TracesAction.summary(trace).toJSONString());
                 }
             }
         });
@@ -194,6 +206,7 @@ public class AdminServer implements ServerMonitor, ConfigurableFeature {
         if (metricsScheduler != null) {
             metricsScheduler.shutdownNow();
         }
+        TraceStore.getInstance().setListener(null);
         broadcaster.shutdown();
         System.getProperties().remove(RequestLogAction.LOG_KEY);
         if (metrics != null) {

--- a/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/AdminServer.java
+++ b/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/AdminServer.java
@@ -6,9 +6,13 @@ import net.unit8.waitt.api.EmbeddedServer;
 import net.unit8.waitt.api.ServerMonitor;
 import net.unit8.waitt.api.configuration.Feature;
 import net.unit8.waitt.api.configuration.WebappConfiguration;
+import net.unit8.waitt.feature.admin.json.JSONObject;
 import net.unit8.waitt.feature.admin.routes.*;
 
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryUsage;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Map;
@@ -23,8 +27,10 @@ import java.util.logging.Logger;
  */
 public class AdminServer implements ServerMonitor, ConfigurableFeature {
     private static final Logger LOG = Logger.getLogger(AdminServer.class.getName());
+    private static final int DEFAULT_LOG_BUFFER_SIZE = 1000;
+    private static final long METRICS_INTERVAL_MILLIS = 2000L;
 
-    final ExecutorService executorService = new ThreadPoolExecutor(1, 10, 15L, TimeUnit.SECONDS,
+    final ExecutorService executorService = new ThreadPoolExecutor(1, 20, 15L, TimeUnit.SECONDS,
             new SynchronousQueue<Runnable>(),
             new ThreadFactory() {
                 private final AtomicInteger counter = new AtomicInteger(0);
@@ -45,22 +51,16 @@ public class AdminServer implements ServerMonitor, ConfigurableFeature {
     String rrdPath;
 
     final AdminApplication app = new AdminApplication();
-    PrometheusAction prometheusAction;
+    final EventBroadcaster broadcaster = EventBroadcaster.getInstance();
+    AdminMetrics metrics;
+    LogBuffer logBuffer;
+    ConsoleCapture consoleCapture;
+    ScheduledExecutorService metricsScheduler;
     int adminPort = 1192;
 
     @Override
     public void config(WebappConfiguration config) {
-        app.addRoutes(new CorsAction());
-        app.addRoutes(new AppAction(config));
-        app.addRoutes(new EnvPropertyAction());
-        app.addRoutes(new ThreadDumpAction());
-        app.addRoutes(new HeapDumpAction());
-        app.addRoutes(new LoggersAction());
-        app.addRoutes(new StartupAction());
-        app.addRoutes(new RequestLogAction());
-        prometheusAction = new PrometheusAction();
-        app.addRoutes(prometheusAction);
-
+        int logBufferSize = DEFAULT_LOG_BUFFER_SIZE;
         for (Feature feature : config.getFeatures()) {
             if ("waitt-admin".equals(feature.getArtifactId()) && "net.unit8.waitt.feature".equals(feature.getGroupId())) {
                 Map<String, String> featureConfig = feature.getConfiguration();
@@ -73,20 +73,52 @@ public class AdminServer implements ServerMonitor, ConfigurableFeature {
                             LOG.warning("Invalid admin.port value: " + portStr + ", using default port " + adminPort);
                         }
                     }
+                    String bufStr = featureConfig.get("log.buffer.size");
+                    if (bufStr != null) {
+                        try {
+                            logBufferSize = Integer.parseInt(bufStr);
+                        } catch (NumberFormatException e) {
+                            LOG.warning("Invalid log.buffer.size value: " + bufStr + ", using default " + logBufferSize);
+                        }
+                    }
                 }
             }
         }
+
+        metrics = new AdminMetrics();
+        logBuffer = new LogBuffer(logBufferSize);
+        consoleCapture = new ConsoleCapture(logBuffer, broadcaster);
+
+        app.addRoutes(new CorsAction());
+        app.addRoutes(new AppAction(config));
+        app.addRoutes(new EnvPropertyAction());
+        app.addRoutes(new ThreadDumpAction());
+        app.addRoutes(new HeapDumpAction());
+        app.addRoutes(new LoggersAction());
+        app.addRoutes(new StartupAction());
+        app.addRoutes(new RequestLogAction());
+        app.addRoutes(new PrometheusAction(metrics));
+        app.addRoutes(new StreamAction(broadcaster));
+        app.addRoutes(new LogsAction(logBuffer));
+
         rrdPath = "target/rrd/" + config.getApplicationName() + ".rrd";
     }
 
     @Override
     public void init(EmbeddedServer server) {
         executorService.execute(new MonitoringPost(rrdPath));
-        // Set up request listener for application request logging
+        // Set up request listener for application request logging and metrics.
+        // This runs on the application's request thread (Tomcat Valve / Jetty
+        // Handler), so a telemetry hiccup must never break the request.
         server.setRequestListener(new EmbeddedServer.RequestListener() {
             @Override
             public void onRequest(String method, String path, int status, long durationMs) {
-                RequestLogAction.record(method, path, status, durationMs);
+                try {
+                    RequestLogAction.record(method, path, status, durationMs);
+                    metrics.recordHttpRequest(method, status, durationMs);
+                } catch (RuntimeException e) {
+                    LOG.log(Level.FINE, "Failed to record request telemetry", e);
+                }
             }
         });
     }
@@ -108,14 +140,64 @@ public class AdminServer implements ServerMonitor, ConfigurableFeature {
             adminServer.start();
         } catch (IOException ex) {
             LOG.log(Level.SEVERE, "Failed to start an admin server.", ex);
+            return;
         }
+        // Only take global side effects (console tee, metrics ticker) once the
+        // dashboard is actually reachable.
+        consoleCapture.install();
+        startMetricsScheduler();
+    }
+
+    private void startMetricsScheduler() {
+        metricsScheduler = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable runnable) {
+                Thread t = new Thread(runnable, "admin-metrics-ticker");
+                t.setDaemon(true);
+                return t;
+            }
+        });
+        metricsScheduler.scheduleAtFixedRate(new Runnable() {
+            @Override
+            public void run() {
+                if (!broadcaster.hasSubscribers()) {
+                    return;
+                }
+                try {
+                    broadcaster.publish("metrics", metricsSnapshot());
+                } catch (RuntimeException e) {
+                    LOG.log(Level.FINE, "Failed to publish metrics snapshot", e);
+                }
+            }
+        }, METRICS_INTERVAL_MILLIS, METRICS_INTERVAL_MILLIS, TimeUnit.MILLISECONDS);
+    }
+
+    private String metricsSnapshot() {
+        MemoryMXBean memory = ManagementFactory.getMemoryMXBean();
+        MemoryUsage heap = memory.getHeapMemoryUsage();
+        MemoryUsage nonHeap = memory.getNonHeapMemoryUsage();
+        JSONObject json = new JSONObject();
+        json.put("timestamp", System.currentTimeMillis());
+        json.put("heapUsed", heap.getUsed());
+        json.put("heapCommitted", heap.getCommitted());
+        json.put("heapMax", heap.getMax());
+        json.put("nonHeapUsed", nonHeap.getUsed());
+        json.put("threadCount", ManagementFactory.getThreadMXBean().getThreadCount());
+        return json.toJSONString();
     }
 
     @Override
     public void stop() {
+        if (consoleCapture != null) {
+            consoleCapture.restore();
+        }
+        if (metricsScheduler != null) {
+            metricsScheduler.shutdownNow();
+        }
+        broadcaster.shutdown();
         System.getProperties().remove(RequestLogAction.LOG_KEY);
-        if (prometheusAction != null) {
-            prometheusAction.close();
+        if (metrics != null) {
+            metrics.close();
         }
         if (adminServer != null) {
             adminServer.stop(0);

--- a/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/ConsoleCapture.java
+++ b/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/ConsoleCapture.java
@@ -72,8 +72,12 @@ public class ConsoleCapture {
         LogEntry entry = new LogEntry(now, streamName, line);
         buffer.add(entry);
         // Correlate to the in-flight request when this line was written on a
-        // request thread (no-op when tracing is off or no trace is current).
-        TraceStore.getInstance().recordLog(new LogLine(now, streamName, line));
+        // request thread. Guard on isEnabled() so the common no-tracer case does
+        // not allocate a throwaway LogLine per console line.
+        TraceStore store = TraceStore.getInstance();
+        if (store.isEnabled()) {
+            store.recordLog(new LogLine(now, streamName, line));
+        }
         if (broadcaster.hasSubscribers()) {
             broadcaster.publish("log", entry.toJSON().toJSONString());
         }

--- a/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/ConsoleCapture.java
+++ b/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/ConsoleCapture.java
@@ -1,5 +1,8 @@
 package net.unit8.waitt.feature.admin;
 
+import net.unit8.waitt.api.observability.LogLine;
+import net.unit8.waitt.api.observability.TraceStore;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -65,8 +68,12 @@ public class ConsoleCapture {
     }
 
     private void emit(String streamName, String line) {
-        LogEntry entry = new LogEntry(System.currentTimeMillis(), streamName, line);
+        long now = System.currentTimeMillis();
+        LogEntry entry = new LogEntry(now, streamName, line);
         buffer.add(entry);
+        // Correlate to the in-flight request when this line was written on a
+        // request thread (no-op when tracing is off or no trace is current).
+        TraceStore.getInstance().recordLog(new LogLine(now, streamName, line));
         if (broadcaster.hasSubscribers()) {
             broadcaster.publish("log", entry.toJSON().toJSONString());
         }

--- a/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/ConsoleCapture.java
+++ b/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/ConsoleCapture.java
@@ -1,0 +1,125 @@
+package net.unit8.waitt.feature.admin;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+
+/**
+ * Tees {@code System.out}/{@code System.err} into a {@link LogBuffer} and the
+ * {@link EventBroadcaster}, while writing every byte through to the original
+ * stream so the terminal still shows everything.
+ * <p>
+ * The original stream references are captured before replacement, so waitt's own
+ * stderr logging cannot feed back into the capture. Bytes are assembled into
+ * newline-delimited lines; each completed line becomes one {@link LogEntry}.
+ *
+ * @author kawasima
+ */
+public class ConsoleCapture {
+    private static final Charset CONSOLE_CHARSET = Charset.defaultCharset();
+
+    private final LogBuffer buffer;
+    private final EventBroadcaster broadcaster;
+
+    private PrintStream originalOut;
+    private PrintStream originalErr;
+    private boolean installed;
+
+    public ConsoleCapture(LogBuffer buffer, EventBroadcaster broadcaster) {
+        this.buffer = buffer;
+        this.broadcaster = broadcaster;
+    }
+
+    public synchronized void install() {
+        if (installed) {
+            return;
+        }
+        originalOut = System.out;
+        originalErr = System.err;
+        System.setOut(newTee(originalOut, "OUT"));
+        System.setErr(newTee(originalErr, "ERR"));
+        installed = true;
+    }
+
+    public synchronized void restore() {
+        if (!installed) {
+            return;
+        }
+        System.setOut(originalOut);
+        System.setErr(originalErr);
+        installed = false;
+    }
+
+    private PrintStream newTee(PrintStream delegate, String streamName) {
+        // Encode with the console's own charset so the bytes forwarded to the
+        // original stream match what the terminal expects (avoids mojibake on
+        // non-UTF-8 consoles such as Windows MS932).
+        try {
+            return new PrintStream(new LineTeeOutputStream(delegate, streamName), true, CONSOLE_CHARSET.name());
+        } catch (UnsupportedEncodingException e) {
+            return delegate;
+        }
+    }
+
+    private void emit(String streamName, String line) {
+        LogEntry entry = new LogEntry(System.currentTimeMillis(), streamName, line);
+        buffer.add(entry);
+        if (broadcaster.hasSubscribers()) {
+            broadcaster.publish("log", entry.toJSON().toJSONString());
+        }
+    }
+
+    /**
+     * Writes every byte through to the delegate and assembles complete lines.
+     */
+    private final class LineTeeOutputStream extends OutputStream {
+        private final PrintStream delegate;
+        private final String streamName;
+        private final ByteArrayOutputStream lineBuf = new ByteArrayOutputStream(128);
+
+        LineTeeOutputStream(PrintStream delegate, String streamName) {
+            this.delegate = delegate;
+            this.streamName = streamName;
+        }
+
+        @Override
+        public synchronized void write(int b) {
+            delegate.write(b);
+            appendByte((byte) b);
+        }
+
+        @Override
+        public synchronized void write(byte[] b, int off, int len) {
+            delegate.write(b, off, len);
+            for (int i = 0; i < len; i++) {
+                appendByte(b[off + i]);
+            }
+        }
+
+        private void appendByte(byte b) {
+            if (b == '\n') {
+                flushLine();
+            } else {
+                lineBuf.write(b);
+            }
+        }
+
+        private void flushLine() {
+            byte[] raw = lineBuf.toByteArray();
+            lineBuf.reset();
+            int len = raw.length;
+            if (len > 0 && raw[len - 1] == '\r') {
+                len--; // strip trailing CR from CRLF line endings
+            }
+            emit(streamName, new String(raw, 0, len, CONSOLE_CHARSET));
+        }
+
+        @Override
+        public void flush() throws IOException {
+            delegate.flush();
+        }
+    }
+}

--- a/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/EventBroadcaster.java
+++ b/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/EventBroadcaster.java
@@ -1,0 +1,111 @@
+package net.unit8.waitt.feature.admin;
+
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-process publish/subscribe hub feeding the Server-Sent Events endpoint.
+ * <p>
+ * Producers (request log, console capture, metrics ticker) call
+ * {@link #publish(String, String)}; each open SSE connection is a
+ * {@link Subscriber} draining its own bounded queue. Publishing never blocks a
+ * producer: when a subscriber's queue is full the oldest event is dropped, since
+ * development-time observability data is loss-tolerant and a slow browser must
+ * never slow the application.
+ *
+ * @author kawasima
+ */
+public class EventBroadcaster {
+    private static final EventBroadcaster INSTANCE = new EventBroadcaster();
+
+    /** Per-subscriber queue capacity before the oldest event is dropped. */
+    static final int QUEUE_CAPACITY = 256;
+
+    private final Set<Subscriber> subscribers = ConcurrentHashMap.newKeySet();
+    private final Object subscribeLock = new Object();
+
+    private EventBroadcaster() {
+    }
+
+    public static EventBroadcaster getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * One event: a Server-Sent Events {@code type} and a pre-serialized JSON
+     * {@code data} payload (already escaped to a single line).
+     */
+    public static final class Event {
+        public final String type;
+        public final String data;
+
+        public Event(String type, String data) {
+            this.type = type;
+            this.data = data;
+        }
+    }
+
+    /** A single SSE connection draining events from its own bounded queue. */
+    public static final class Subscriber {
+        private final BlockingQueue<Event> queue = new ArrayBlockingQueue<Event>(QUEUE_CAPACITY);
+
+        public Event poll(long timeoutMillis) throws InterruptedException {
+            return queue.poll(timeoutMillis, java.util.concurrent.TimeUnit.MILLISECONDS);
+        }
+
+        void offerDroppingOldest(Event event) {
+            while (!queue.offer(event)) {
+                queue.poll();
+            }
+        }
+    }
+
+    public Subscriber subscribe() {
+        Subscriber subscriber = new Subscriber();
+        subscribers.add(subscriber);
+        return subscriber;
+    }
+
+    /**
+     * Atomically subscribe only if the current count is below {@code max};
+     * returns {@code null} when the cap is already reached. This closes the
+     * check-then-act race a separate count-then-subscribe would leave open.
+     */
+    public Subscriber subscribeIfBelow(int max) {
+        synchronized (subscribeLock) {
+            if (subscribers.size() >= max) {
+                return null;
+            }
+            return subscribe();
+        }
+    }
+
+    public void unsubscribe(Subscriber subscriber) {
+        subscribers.remove(subscriber);
+    }
+
+    public int subscriberCount() {
+        return subscribers.size();
+    }
+
+    public boolean hasSubscribers() {
+        return !subscribers.isEmpty();
+    }
+
+    public void publish(String type, String jsonData) {
+        if (subscribers.isEmpty()) {
+            return;
+        }
+        Event event = new Event(type, jsonData);
+        for (Subscriber subscriber : subscribers) {
+            subscriber.offerDroppingOldest(event);
+        }
+    }
+
+    /** Drop all subscribers (called on admin server shutdown). */
+    public void shutdown() {
+        subscribers.clear();
+    }
+}

--- a/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/LogBuffer.java
+++ b/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/LogBuffer.java
@@ -1,0 +1,40 @@
+package net.unit8.waitt.feature.admin;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * Fixed-capacity ring buffer of recent console lines. When full, appending a new
+ * entry evicts the oldest. Snapshots are returned oldest to newest.
+ *
+ * @author kawasima
+ */
+public class LogBuffer {
+    private final int capacity;
+    private final Deque<LogEntry> entries;
+
+    public LogBuffer(int capacity) {
+        this.capacity = capacity < 1 ? 1 : capacity;
+        // Grow lazily; the ring is bounded by add()'s own size check, so we must
+        // not preallocate a backing array sized to a (possibly huge) capacity.
+        this.entries = new ArrayDeque<LogEntry>();
+    }
+
+    public synchronized void add(LogEntry entry) {
+        if (entries.size() >= capacity) {
+            entries.pollFirst();
+        }
+        entries.addLast(entry);
+    }
+
+    /** Snapshot of the buffered entries, oldest first. */
+    public synchronized List<LogEntry> snapshot() {
+        return new ArrayList<LogEntry>(entries);
+    }
+
+    public synchronized int size() {
+        return entries.size();
+    }
+}

--- a/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/LogEntry.java
+++ b/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/LogEntry.java
@@ -1,0 +1,29 @@
+package net.unit8.waitt.feature.admin;
+
+import net.unit8.waitt.feature.admin.json.JSONObject;
+
+/**
+ * One captured console line: when it was written, which stream it came from
+ * ({@code OUT} or {@code ERR}), and the raw text (no trailing newline).
+ *
+ * @author kawasima
+ */
+public final class LogEntry {
+    public final long timestamp;
+    public final String stream;
+    public final String text;
+
+    public LogEntry(long timestamp, String stream, String text) {
+        this.timestamp = timestamp;
+        this.stream = stream;
+        this.text = text;
+    }
+
+    public JSONObject toJSON() {
+        JSONObject json = new JSONObject();
+        json.put("timestamp", timestamp);
+        json.put("stream", stream);
+        json.put("text", text);
+        return json;
+    }
+}

--- a/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/ResponseUtils.java
+++ b/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/ResponseUtils.java
@@ -8,6 +8,7 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
+import java.util.Locale;
 
 public class ResponseUtils {
     public static void sendError(HttpExchange exchange, int status, String message) throws IOException {
@@ -29,6 +30,10 @@ public class ResponseUtils {
         }
         try {
             String host = new URI(origin).getHost();
+            if (host == null) {
+                return false;
+            }
+            host = host.toLowerCase(Locale.ROOT); // hostnames are case-insensitive
             return "localhost".equals(host)
                     || "127.0.0.1".equals(host)
                     || "::1".equals(host)
@@ -53,6 +58,8 @@ public class ResponseUtils {
 
     public static void responseJSON(HttpExchange exchange, JSONObject jsonObject) throws IOException {
         applyCorsOrigin(exchange);
+        exchange.getResponseHeaders().put("Content-Type",
+                Collections.singletonList("application/json; charset=utf-8"));
         byte[] json = jsonObject.toJSONString().getBytes("UTF-8");
         exchange.sendResponseHeaders(200, json.length);
         try (OutputStream os = exchange.getResponseBody()) {

--- a/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/ResponseUtils.java
+++ b/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/ResponseUtils.java
@@ -5,6 +5,8 @@ import net.unit8.waitt.feature.admin.json.JSONObject;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collections;
 
 public class ResponseUtils {
@@ -16,12 +18,41 @@ public class ResponseUtils {
         }
     }
 
-    public static void responseJSON(HttpExchange exchange, JSONObject jsonObject) throws IOException {
+    /**
+     * True only when the Origin's host is exactly a loopback host. A prefix
+     * check like {@code startsWith("http://localhost")} would also accept a
+     * hostile origin such as {@code http://localhost.attacker.example}.
+     */
+    static boolean isLocalOrigin(String origin) {
+        if (origin == null) {
+            return false;
+        }
+        try {
+            String host = new URI(origin).getHost();
+            return "localhost".equals(host)
+                    || "127.0.0.1".equals(host)
+                    || "::1".equals(host)
+                    || "[::1]".equals(host);
+        } catch (URISyntaxException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Echo the request Origin into the CORS allow-origin header only when it is
+     * a loopback origin. Shared by every admin route that answers cross-origin
+     * fetches so the allow-list lives in one place.
+     */
+    public static void applyCorsOrigin(HttpExchange exchange) {
         String origin = exchange.getRequestHeaders().getFirst("Origin");
-        if (origin != null && origin.startsWith("http://localhost")) {
+        if (isLocalOrigin(origin)) {
             exchange.getResponseHeaders().put("Access-Control-Allow-Origin", Collections.singletonList(origin));
         }
         exchange.getResponseHeaders().put("Access-Control-Allow-Headers", Collections.singletonList("Content-Type, Accept"));
+    }
+
+    public static void responseJSON(HttpExchange exchange, JSONObject jsonObject) throws IOException {
+        applyCorsOrigin(exchange);
         byte[] json = jsonObject.toJSONString().getBytes("UTF-8");
         exchange.sendResponseHeaders(200, json.length);
         try (OutputStream os = exchange.getResponseBody()) {

--- a/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/routes/CorsAction.java
+++ b/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/routes/CorsAction.java
@@ -1,11 +1,11 @@
 package net.unit8.waitt.feature.admin.routes;
 
 import com.sun.net.httpserver.HttpExchange;
+import net.unit8.waitt.feature.admin.ResponseUtils;
 import net.unit8.waitt.feature.admin.Route;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 
 public class CorsAction implements Route {
     @Override
@@ -15,10 +15,10 @@ public class CorsAction implements Route {
 
     @Override
     public void handle(HttpExchange exchange) throws IOException {
-        exchange.getResponseHeaders().put("Access-Control-Allow-Origin",
-                Collections.singletonList("http://localhost:" + exchange.getLocalAddress().getPort()));
-        exchange.getResponseHeaders().put("Access-Control-Allow-Headers",
-                Arrays.asList("Content-Type", "Accept"));
+        // Reuse the same loopback allow-list the actual GET/POST routes use, so
+        // a preflight from 127.0.0.1 / [::1] doesn't fail where the real request
+        // would succeed.
+        ResponseUtils.applyCorsOrigin(exchange);
         exchange.getResponseHeaders().put("Access-Control-Allow-Methods",
                 Arrays.asList("GET", "POST", "OPTIONS"));
         exchange.sendResponseHeaders(200, -1);

--- a/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/routes/LogsAction.java
+++ b/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/routes/LogsAction.java
@@ -1,0 +1,45 @@
+package net.unit8.waitt.feature.admin.routes;
+
+import com.sun.net.httpserver.HttpExchange;
+import net.unit8.waitt.feature.admin.LogBuffer;
+import net.unit8.waitt.feature.admin.LogEntry;
+import net.unit8.waitt.feature.admin.ResponseUtils;
+import net.unit8.waitt.feature.admin.Route;
+import net.unit8.waitt.feature.admin.json.JSONObject;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Serves a snapshot of the captured console lines. Live updates arrive over
+ * {@code /stream} as {@code log} events; this endpoint seeds the initial view.
+ *
+ * @author kawasima
+ */
+public class LogsAction implements Route {
+    private final LogBuffer buffer;
+
+    public LogsAction(LogBuffer buffer) {
+        this.buffer = buffer;
+    }
+
+    @Override
+    public boolean canHandle(HttpExchange exchange) {
+        return "GET".equalsIgnoreCase(exchange.getRequestMethod())
+                && "/logs".equals(exchange.getRequestURI().getPath());
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        List<LogEntry> entries = buffer.snapshot();
+        List<JSONObject> logs = new ArrayList<JSONObject>(entries.size());
+        for (LogEntry entry : entries) {
+            logs.add(entry.toJSON());
+        }
+        JSONObject json = new JSONObject();
+        json.put("logs", logs);
+        json.put("total", entries.size());
+        ResponseUtils.responseJSON(exchange, json);
+    }
+}

--- a/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/routes/PrometheusAction.java
+++ b/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/routes/PrometheusAction.java
@@ -1,33 +1,24 @@
 package net.unit8.waitt.feature.admin.routes;
 
 import com.sun.net.httpserver.HttpExchange;
-import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
-import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
-import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
-import io.micrometer.prometheus.PrometheusConfig;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
+import net.unit8.waitt.feature.admin.AdminMetrics;
+import net.unit8.waitt.feature.admin.ResponseUtils;
 import net.unit8.waitt.feature.admin.Route;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collections;
 
 /**
- * Expose Prometheus metrics.
+ * Expose Prometheus metrics from the shared {@link AdminMetrics} registry.
  *
  * @author kawasima
  */
-public class PrometheusAction implements Route, Closeable {
-    private final PrometheusMeterRegistry registry;
-    private final JvmGcMetrics gcMetrics;
+public class PrometheusAction implements Route {
+    private final AdminMetrics metrics;
 
-    public PrometheusAction() {
-        registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
-        gcMetrics = new JvmGcMetrics();
-        gcMetrics.bindTo(registry);
-        new JvmMemoryMetrics().bindTo(registry);
-        new JvmThreadMetrics().bindTo(registry);
+    public PrometheusAction(AdminMetrics metrics) {
+        this.metrics = metrics;
     }
 
     @Override
@@ -38,18 +29,13 @@ public class PrometheusAction implements Route, Closeable {
 
     @Override
     public void handle(HttpExchange exchange) throws IOException {
-        byte[] body = registry.scrape().getBytes("UTF-8");
+        byte[] body = metrics.scrape().getBytes("UTF-8");
         exchange.getResponseHeaders().put("Content-Type",
                 Collections.singletonList("text/plain; version=0.0.4; charset=utf-8"));
+        ResponseUtils.applyCorsOrigin(exchange);
         exchange.sendResponseHeaders(200, body.length);
         try (OutputStream os = exchange.getResponseBody()) {
             os.write(body);
         }
-    }
-
-    @Override
-    public void close() {
-        gcMetrics.close();
-        registry.close();
     }
 }

--- a/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/routes/ReloadAction.java
+++ b/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/routes/ReloadAction.java
@@ -2,10 +2,10 @@ package net.unit8.waitt.feature.admin.routes;
 
 import com.sun.net.httpserver.HttpExchange;
 import net.unit8.waitt.api.EmbeddedServer;
+import net.unit8.waitt.feature.admin.ResponseUtils;
 import net.unit8.waitt.feature.admin.Route;
 
 import java.io.IOException;
-import java.util.Collections;
 
 /**
  * Provide a feature to reload the server.
@@ -28,11 +28,7 @@ public class ReloadAction implements Route {
     @Override
     public void handle(HttpExchange exchange) throws IOException {
         server.reload();
-        String origin = exchange.getRequestHeaders().getFirst("Origin");
-        if (origin != null && origin.startsWith("http://localhost")) {
-            exchange.getResponseHeaders().put("Access-Control-Allow-Origin", Collections.singletonList(origin));
-        }
-        exchange.getResponseHeaders().put("Access-Control-Allow-Headers", Collections.singletonList("Content-Type, Accept"));
+        ResponseUtils.applyCorsOrigin(exchange);
         exchange.sendResponseHeaders(204, -1);
     }
 }

--- a/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/routes/RequestLogAction.java
+++ b/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/routes/RequestLogAction.java
@@ -1,6 +1,7 @@
 package net.unit8.waitt.feature.admin.routes;
 
 import com.sun.net.httpserver.HttpExchange;
+import net.unit8.waitt.feature.admin.EventBroadcaster;
 import net.unit8.waitt.feature.admin.ResponseUtils;
 import net.unit8.waitt.feature.admin.Route;
 import net.unit8.waitt.feature.admin.json.JSONObject;
@@ -46,6 +47,13 @@ public class RequestLogAction implements Route {
         log.addFirst(entry);
         while (log.size() > MAX_ENTRIES) {
             if (log.pollLast() == null) break;
+        }
+
+        EventBroadcaster broadcaster = EventBroadcaster.getInstance();
+        if (broadcaster.hasSubscribers()) {
+            JSONObject event = new JSONObject();
+            event.putAll(entry);
+            broadcaster.publish("request", event.toJSONString());
         }
     }
 

--- a/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/routes/StreamAction.java
+++ b/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/routes/StreamAction.java
@@ -1,0 +1,84 @@
+package net.unit8.waitt.feature.admin.routes;
+
+import com.sun.net.httpserver.HttpExchange;
+import net.unit8.waitt.feature.admin.EventBroadcaster;
+import net.unit8.waitt.feature.admin.ResponseUtils;
+import net.unit8.waitt.feature.admin.Route;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.util.Collections;
+
+/**
+ * Server-Sent Events stream of live {@code request}, {@code log}, and
+ * {@code metrics} events.
+ * <p>
+ * The handler thread stays parked on this connection for its lifetime, draining
+ * the subscriber queue and writing frames. It returns only when the client
+ * disconnects (a write {@link IOException}), at which point
+ * {@code AdminApplication} closes the exchange. Concurrent streams are capped so
+ * a runaway set of browser tabs cannot exhaust the admin thread pool.
+ *
+ * @author kawasima
+ */
+public class StreamAction implements Route {
+    /** Maximum concurrent SSE connections; extra requests get 503. */
+    static final int MAX_STREAMS = 8;
+    /** Idle timeout after which a heartbeat comment is written. */
+    private static final long HEARTBEAT_MILLIS = 15000L;
+
+    private static final Charset UTF8 = Charset.forName("UTF-8");
+
+    private final EventBroadcaster broadcaster;
+
+    public StreamAction(EventBroadcaster broadcaster) {
+        this.broadcaster = broadcaster;
+    }
+
+    @Override
+    public boolean canHandle(HttpExchange exchange) {
+        return "GET".equalsIgnoreCase(exchange.getRequestMethod())
+                && "/stream".equals(exchange.getRequestURI().getPath());
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        // Atomically claim a slot so concurrent connects can't exceed the cap.
+        EventBroadcaster.Subscriber subscriber = broadcaster.subscribeIfBelow(MAX_STREAMS);
+        if (subscriber == null) {
+            exchange.sendResponseHeaders(503, -1);
+            return;
+        }
+
+        try {
+            exchange.getResponseHeaders().put("Content-Type", Collections.singletonList("text/event-stream; charset=utf-8"));
+            exchange.getResponseHeaders().put("Cache-Control", Collections.singletonList("no-cache"));
+            exchange.getResponseHeaders().put("Connection", Collections.singletonList("keep-alive"));
+            ResponseUtils.applyCorsOrigin(exchange);
+            exchange.sendResponseHeaders(200, 0); // 0 -> chunked, keep the response open
+
+            OutputStream os = exchange.getResponseBody();
+            write(os, ": connected\n\n"); // initial comment so the client's onopen fires
+            while (true) {
+                EventBroadcaster.Event event = subscriber.poll(HEARTBEAT_MILLIS);
+                if (event == null) {
+                    write(os, ": ping\n\n"); // heartbeat / dead-connection detection
+                } else {
+                    write(os, "event: " + event.type + "\ndata: " + event.data + "\n\n");
+                }
+            }
+        } catch (IOException disconnected) {
+            // Client went away; fall through to unsubscribe.
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+        } finally {
+            broadcaster.unsubscribe(subscriber);
+        }
+    }
+
+    private void write(OutputStream os, String frame) throws IOException {
+        os.write(frame.getBytes(UTF8));
+        os.flush();
+    }
+}

--- a/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/routes/TracesAction.java
+++ b/waitt-admin/src/main/java/net/unit8/waitt/feature/admin/routes/TracesAction.java
@@ -1,0 +1,150 @@
+package net.unit8.waitt.feature.admin.routes;
+
+import com.sun.net.httpserver.HttpExchange;
+import net.unit8.waitt.api.observability.LogLine;
+import net.unit8.waitt.api.observability.RequestTrace;
+import net.unit8.waitt.api.observability.SpanRecord;
+import net.unit8.waitt.api.observability.SqlEvent;
+import net.unit8.waitt.api.observability.TraceStore;
+import net.unit8.waitt.feature.admin.ResponseUtils;
+import net.unit8.waitt.feature.admin.Route;
+import net.unit8.waitt.feature.admin.json.JSONObject;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Serves the correlated request traces from {@link TraceStore}:
+ * {@code GET /traces} lists recent traces (summaries), {@code GET /traces/{id}}
+ * returns one trace's full detail (spans, SQL, logs, exception). Live updates
+ * arrive over {@code /stream} as {@code trace} events.
+ *
+ * @author kawasima
+ */
+public class TracesAction implements Route {
+    private static final String PREFIX = "/traces";
+
+    @Override
+    public boolean canHandle(HttpExchange exchange) {
+        if (!"GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+            return false;
+        }
+        String path = exchange.getRequestURI().getPath();
+        return PREFIX.equals(path) || path.startsWith(PREFIX + "/");
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        String path = exchange.getRequestURI().getPath();
+        if (PREFIX.equals(path)) {
+            handleList(exchange);
+        } else {
+            handleDetail(exchange, path.substring(PREFIX.length() + 1));
+        }
+    }
+
+    private void handleList(HttpExchange exchange) throws IOException {
+        List<RequestTrace> traces = TraceStore.getInstance().recentTraces();
+        List<JSONObject> list = new ArrayList<JSONObject>(traces.size());
+        for (RequestTrace trace : traces) {
+            list.add(summary(trace));
+        }
+        JSONObject json = new JSONObject();
+        json.put("traces", list);
+        json.put("total", traces.size());
+        ResponseUtils.responseJSON(exchange, json);
+    }
+
+    private void handleDetail(HttpExchange exchange, String traceId) throws IOException {
+        RequestTrace trace = TraceStore.getInstance().getTrace(traceId);
+        if (trace == null) {
+            ResponseUtils.sendError(exchange, 404, "Trace not found");
+            return;
+        }
+        ResponseUtils.responseJSON(exchange, detail(trace));
+    }
+
+    public static JSONObject summary(RequestTrace trace) {
+        JSONObject o = new JSONObject();
+        o.put("traceId", trace.getTraceId());
+        o.put("method", trace.getMethod());
+        o.put("path", trace.getPath());
+        o.put("statusCode", trace.getStatusCode());
+        o.put("startEpochMillis", trace.getStartEpochMillis());
+        o.put("durationMillis", trace.getDurationMillis());
+        o.put("spanCount", trace.getSpans().size());
+        o.put("sqlCount", trace.getSqlEvents().size());
+        o.put("logCount", trace.getLogs().size());
+        o.put("hasError", trace.getExceptionType() != null || trace.getStatusCode() >= 500);
+        return o;
+    }
+
+    private JSONObject detail(RequestTrace trace) {
+        JSONObject o = summary(trace);
+
+        // Absolute epoch nanos (~1.8e18) exceed JS's safe-integer range, so emit
+        // offsets relative to the earliest span start (small longs the browser can
+        // position exactly) plus the total window for the waterfall.
+        long minStart = Long.MAX_VALUE;
+        long maxEnd = Long.MIN_VALUE;
+        for (SpanRecord span : trace.getSpans()) {
+            minStart = Math.min(minStart, span.getStartEpochNanos());
+            maxEnd = Math.max(maxEnd, span.getEndEpochNanos());
+        }
+        long windowNanos = trace.getSpans().isEmpty() ? 0 : (maxEnd - minStart);
+        o.put("windowNanos", windowNanos);
+
+        List<JSONObject> spans = new ArrayList<JSONObject>();
+        for (SpanRecord span : trace.getSpans()) {
+            JSONObject s = new JSONObject();
+            s.put("spanId", span.getSpanId());
+            s.put("parentSpanId", span.getParentSpanId());
+            s.put("name", span.getName());
+            s.put("startOffsetNanos", span.getStartEpochNanos() - minStart);
+            s.put("durationNanos", span.getDurationNanos());
+            s.put("error", span.isError());
+            s.put("database", span.isDatabase());
+            JSONObject attrs = new JSONObject();
+            for (Map.Entry<String, String> e : span.getAttributes().entrySet()) {
+                attrs.put(e.getKey(), e.getValue());
+            }
+            s.put("attributes", attrs);
+            spans.add(s);
+        }
+        o.put("spans", spans);
+
+        List<JSONObject> sqls = new ArrayList<JSONObject>();
+        for (SqlEvent sql : trace.getSqlEvents()) {
+            JSONObject q = new JSONObject();
+            q.put("startEpochMillis", sql.getStartEpochMillis());
+            q.put("durationMillis", sql.getDurationMillis());
+            q.put("sql", sql.getSql());
+            q.put("rowCount", sql.getRowCount());
+            q.put("success", sql.isSuccess());
+            q.put("error", sql.getError());
+            sqls.add(q);
+        }
+        o.put("sqlEvents", sqls);
+
+        List<JSONObject> logs = new ArrayList<JSONObject>();
+        for (LogLine line : trace.getLogs()) {
+            JSONObject l = new JSONObject();
+            l.put("timestamp", line.getTimestampMillis());
+            l.put("stream", line.getStream());
+            l.put("text", line.getText());
+            logs.add(l);
+        }
+        o.put("logs", logs);
+
+        if (trace.getExceptionType() != null) {
+            JSONObject ex = new JSONObject();
+            ex.put("type", trace.getExceptionType());
+            ex.put("message", trace.getExceptionMessage());
+            ex.put("stack", trace.getExceptionStack());
+            o.put("exception", ex);
+        }
+        return o;
+    }
+}

--- a/waitt-admin/src/main/resources/public/css/dashboard.css
+++ b/waitt-admin/src/main/resources/public/css/dashboard.css
@@ -170,3 +170,35 @@ tr.req-5xx td { background: #fdecea; }
 .log-line.log-warn { color: #dcdc7d; }
 .log-line.log-error { color: #f48771; }
 .metrics-scrape { max-height: 60vh; overflow: auto; background: #f8f8f8; padding: .5rem; }
+
+/* Traces */
+tr.trace-row { cursor: pointer; }
+tr.trace-row:hover td { background: #ede9f7; }
+.back-link { display: inline-block; padding: .2rem 0; margin-bottom: .5rem; color: #463381; font-weight: bold; }
+
+/* Waterfall */
+.waterfall { margin-bottom: 1rem; }
+.wf-row { display: flex; align-items: center; margin-bottom: 2px; }
+.wf-label {
+    width: 34%;
+    flex-shrink: 0;
+    font-size: .8em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding-right: .5rem;
+}
+.wf-track { position: relative; flex: 1; height: 18px; background: #f2f2f2; border-radius: 2px; }
+.wf-bar {
+    position: absolute;
+    top: 0;
+    height: 18px;
+    min-width: 2px;
+    background: #6b8fd6;
+    border-radius: 2px;
+    overflow: hidden;
+}
+.wf-bar.wf-db { background: #4caf72; }
+.wf-bar.wf-error { background: #e06c62; }
+.wf-dur { font-size: .7em; color: #fff; padding: 0 .25rem; line-height: 18px; white-space: nowrap; }
+code { font-family: monospace; font-size: .95em; word-break: break-all; }

--- a/waitt-admin/src/main/resources/public/css/dashboard.css
+++ b/waitt-admin/src/main/resources/public/css/dashboard.css
@@ -121,3 +121,52 @@ pre.stack-trace {
 .text-muted { color: #777; font-size: .85em; margin: .2rem 0; }
 .url-list { font-size: .8em; color: #555; max-height: 150px; overflow-y: auto; }
 select { padding: .2rem; font-size: .85em; }
+
+/* Live indicator (masthead) */
+.masthead { display: flex; align-items: center; gap: 1rem; }
+.live-indicator {
+    font-size: .8rem;
+    font-weight: bold;
+    letter-spacing: .02em;
+}
+.live-indicator.live-on { color: #7ed07e; }
+.live-indicator.live-off { color: #b0a9d0; }
+
+/* Inline "live" badge next to page headings */
+.live-badge {
+    font-size: .6em;
+    font-weight: bold;
+    vertical-align: middle;
+    color: #fff;
+    background: #4caf50;
+    border-radius: 3px;
+    padding: .1em .4em;
+    margin-left: .5rem;
+}
+
+/* Request Log status coloring */
+tr.req-4xx td { background: #fff6e5; }
+tr.req-5xx td { background: #fdecea; }
+
+/* Logs page */
+.log-controls { display: flex; gap: .5rem; margin-bottom: .5rem; }
+.log-filter { flex: 1; padding: .3rem .5rem; font-size: .85em; }
+.log-view {
+    font-family: monospace;
+    font-size: .8em;
+    line-height: 1.4;
+    background: #1e1e1e;
+    color: #d4d4d4;
+    padding: .5rem .75rem;
+    border-radius: 4px;
+    height: 60vh;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+}
+.log-line { padding: 0; }
+.log-time { color: #7a7a7a; }
+.log-src { color: #569cd6; }
+.log-line.log-warn { color: #dcdc7d; }
+.log-line.log-error { color: #f48771; }
+.metrics-scrape { max-height: 60vh; overflow: auto; background: #f8f8f8; padding: .5rem; }

--- a/waitt-admin/src/main/resources/public/index.html
+++ b/waitt-admin/src/main/resources/public/index.html
@@ -9,6 +9,7 @@
 <body>
   <header class="masthead">
     <span class="masthead-logo">WAITT</span>
+    <span id="live-indicator" class="live-indicator live-off" title="Live stream status">● live</span>
   </header>
 
   <div class="layout">
@@ -16,7 +17,9 @@
       <ul>
         <li><a class="nav-link" data-page="application">Application</a></li>
         <li><a class="nav-link" data-page="server">Server</a></li>
+        <li><a class="nav-link" data-page="metrics">Metrics</a></li>
         <li><a class="nav-link" data-page="requests">Request Log</a></li>
+        <li><a class="nav-link" data-page="logs">Logs</a></li>
         <li><a class="nav-link" data-page="loggers">Loggers</a></li>
         <li><a class="nav-link" data-page="thread">Thread dump</a></li>
         <li><a class="nav-link" data-page="heap">Heap dump</a></li>
@@ -57,6 +60,11 @@
     }
 
     function setContent(el) {
+      // Swapping content invalidates any previously bound live targets; clear
+      // them so stream events can't append to a detached, off-screen subtree.
+      live.requestsTbody = null;
+      live.requestsEmpty = null;
+      live.logsView = null;
       var c = document.getElementById('content');
       c.innerHTML = '';
       c.appendChild(el);
@@ -289,7 +297,7 @@
         var btn = h('button', { class: 'btn btn-warning' }, ['Reload']);
         btn.addEventListener('click', function () {
           btn.disabled = true;
-          fetch(BASE + '/server/reload', { method: 'POST' })
+          fetch(BASE + '/reload', { method: 'POST' })
             .then(function () { btn.textContent = 'Reloaded'; })
             .catch(function () { btn.textContent = 'Failed'; })
             .finally(function () { btn.disabled = false; });
@@ -299,35 +307,115 @@
       }).catch(function (e) { setContent(errorMsg(e.message)); });
     }
 
+    function requestRow(r) {
+      var time = r.timestamp ? new Date(r.timestamp).toLocaleTimeString() : '';
+      var cls = r.status >= 500 ? 'req-5xx' : (r.status >= 400 ? 'req-4xx' : '');
+      return h('tr', cls ? { class: cls } : {}, [
+        h('td', {}, [time]),
+        h('td', {}, [r.method || '']),
+        h('td', {}, [r.path || '']),
+        h('td', {}, [String(r.status || '')]),
+        h('td', {}, [r.duration !== undefined ? r.duration + 'ms' : '']),
+      ]);
+    }
+
     function pageRequests() {
+      var token = live.navToken;
       setContent(loading());
       apiFetch('/requests').then(function (data) {
+        if (token !== live.navToken) return; // navigated away before this resolved
         var reqs = data.requests || [];
         var div = h('div', {});
-        div.appendChild(h('h2', {}, ['Request Log (' + reqs.length + ' entries)']));
-        if (!reqs.length) {
-          div.appendChild(h('p', {}, ['No requests recorded yet.']));
-          setContent(div); return;
-        }
+        div.appendChild(h('h2', {}, ['Request Log ', h('span', { class: 'live-badge' }, ['live'])]));
         var table = h('table', {});
         table.appendChild(h('thead', {}, [h('tr', {}, [
           h('th', {}, ['Time']), h('th', {}, ['Method']), h('th', {}, ['Path']),
           h('th', {}, ['Status']), h('th', {}, ['Duration'])
         ])]));
         var tbody = h('tbody', {});
-        reqs.forEach(function (r) {
-          var time = r.timestamp ? new Date(r.timestamp).toLocaleTimeString() : '';
-          tbody.appendChild(h('tr', {}, [
-            h('td', {}, [time]),
-            h('td', {}, [r.method || '']),
-            h('td', {}, [r.path || '']),
-            h('td', {}, [String(r.status || '')]),
-            h('td', {}, [r.duration !== undefined ? r.duration + 'ms' : '']),
-          ]));
-        });
+        // /requests returns newest first; render as-is so newest stays on top.
+        reqs.forEach(function (r) { tbody.appendChild(requestRow(r)); });
         table.appendChild(tbody);
         div.appendChild(table);
+        var empty = h('p', { class: 'text-muted' }, ['No requests recorded yet.']);
+        if (reqs.length) empty.style.display = 'none';
+        div.appendChild(empty);
         setContent(div);
+        live.requestsTbody = tbody;
+        live.requestsEmpty = empty;
+      }).catch(function (e) { setContent(errorMsg(e.message)); });
+    }
+
+    function pageMetrics() {
+      setContent(loading());
+      fetch(BASE + '/prometheus', { headers: { Accept: 'text/plain' } })
+        .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.text(); })
+        .then(function (text) {
+          var div = h('div', {});
+          div.appendChild(h('h2', {}, ['Metrics']));
+          div.appendChild(h('p', { class: 'text-muted' },
+            ['Prometheus scrape endpoint (/prometheus). Point Prometheus/Grafana here. Includes http.server.requests after traffic.']));
+          var pre = document.createElement('pre');
+          pre.className = 'stack-trace metrics-scrape';
+          pre.textContent = text;
+          div.appendChild(pre);
+          setContent(div);
+        }).catch(function (e) { setContent(errorMsg(e.message)); });
+    }
+
+    function logLineNode(entry) {
+      var t = entry.timestamp ? new Date(entry.timestamp).toLocaleTimeString() : '';
+      var upper = (entry.text || '').toUpperCase();
+      var cls = 'log-line';
+      if (entry.stream === 'ERR' || upper.indexOf('ERROR') >= 0 || upper.indexOf('SEVERE') >= 0) cls += ' log-error';
+      else if (upper.indexOf('WARN') >= 0) cls += ' log-warn';
+      return h('div', { class: cls }, [
+        h('span', { class: 'log-time' }, [t + ' ']),
+        h('span', { class: 'log-src' }, ['[' + entry.stream + '] ']),
+        document.createTextNode(entry.text || ''),
+      ]);
+    }
+
+    function logMatches(entry) {
+      if (live.logStream !== 'ALL' && entry.stream !== live.logStream) return false;
+      if (live.logFilter && (entry.text || '').toLowerCase().indexOf(live.logFilter) < 0) return false;
+      return true;
+    }
+
+    function renderLogs() {
+      if (!live.logsView) return;
+      live.logsView.innerHTML = '';
+      live.logEntries.forEach(function (entry) {
+        if (logMatches(entry)) live.logsView.appendChild(logLineNode(entry));
+      });
+      live.logsView.scrollTop = live.logsView.scrollHeight;
+    }
+
+    function pageLogs() {
+      var token = live.navToken;
+      setContent(loading());
+      apiFetch('/logs').then(function (data) {
+        if (token !== live.navToken) return; // navigated away before this resolved
+        var div = h('div', {});
+        div.appendChild(h('h2', {}, ['Logs ', h('span', { class: 'live-badge' }, ['live'])]));
+        var controls = h('div', { class: 'log-controls' });
+        var filterInput = h('input', { type: 'text', class: 'log-filter', placeholder: 'filter…' });
+        var streamSel = h('select', {});
+        ['ALL', 'OUT', 'ERR'].forEach(function (s) { streamSel.appendChild(h('option', { value: s }, [s])); });
+        controls.appendChild(filterInput);
+        controls.appendChild(streamSel);
+        div.appendChild(controls);
+        var view = h('div', { class: 'log-view' });
+        div.appendChild(view);
+        setContent(div);
+
+        live.logsView = view;
+        live.logFilter = '';
+        live.logStream = 'ALL';
+        live.logEntries = data.logs || [];
+        filterInput.addEventListener('input', function () { live.logFilter = filterInput.value.toLowerCase(); renderLogs(); });
+        streamSel.addEventListener('change', function () { live.logStream = streamSel.value; renderLogs(); });
+        renderLogs();
       }).catch(function (e) { setContent(errorMsg(e.message)); });
     }
 
@@ -448,12 +536,78 @@
       }).catch(function (e) { setContent(errorMsg(e.message)); });
     }
 
+    // ---- Live stream (SSE) ----
+
+    // Holds references to DOM targets of the currently displayed page so stream
+    // events can update them in place. Cleared on navigation.
+    var live = {
+      navToken: 0,
+      requestsTbody: null,
+      requestsEmpty: null,
+      logsView: null,
+      logEntries: [],
+      logFilter: '',
+      logStream: 'ALL',
+    };
+    var MAX_LIVE_LOG_ENTRIES = 2000;
+
+    function setIndicator(state) {
+      var el = document.getElementById('live-indicator');
+      if (!el) return;
+      el.className = 'live-indicator live-' + state;
+    }
+
+    function onRequestEvent(e) {
+      if (!live.requestsTbody) return;
+      var r = JSON.parse(e.data);
+      live.requestsTbody.insertBefore(requestRow(r), live.requestsTbody.firstChild);
+      if (live.requestsEmpty) live.requestsEmpty.style.display = 'none';
+      while (live.requestsTbody.childNodes.length > 200) {
+        live.requestsTbody.removeChild(live.requestsTbody.lastChild);
+      }
+    }
+
+    function onLogEvent(e) {
+      var entry = JSON.parse(e.data);
+      live.logEntries.push(entry);
+      if (live.logEntries.length > MAX_LIVE_LOG_ENTRIES) live.logEntries.shift();
+      if (live.logsView && logMatches(entry)) {
+        var atBottom = live.logsView.scrollTop + live.logsView.clientHeight >= live.logsView.scrollHeight - 4;
+        live.logsView.appendChild(logLineNode(entry));
+        // Bound the rendered DOM the same way live.logEntries is bounded.
+        while (live.logsView.childNodes.length > MAX_LIVE_LOG_ENTRIES) {
+          live.logsView.removeChild(live.logsView.firstChild);
+        }
+        if (atBottom) live.logsView.scrollTop = live.logsView.scrollHeight;
+      }
+    }
+
+    function onMetricsEvent(e) {
+      var el = document.getElementById('live-indicator');
+      if (!el) return;
+      var m = JSON.parse(e.data);
+      var usedMb = Math.round((m.heapUsed || 0) / 1048576);
+      el.title = 'Heap ' + usedMb + ' MB · ' + (m.threadCount || 0) + ' threads';
+    }
+
+    function connectStream() {
+      if (typeof EventSource === 'undefined') return;
+      var es = new EventSource(BASE + '/stream');
+      es.addEventListener('open', function () { setIndicator('on'); });
+      es.addEventListener('error', function () { setIndicator('off'); });
+      es.addEventListener('request', onRequestEvent);
+      es.addEventListener('log', onLogEvent);
+      es.addEventListener('metrics', onMetricsEvent);
+    }
+
     // ---- Router ----
 
     var pages = {
       application: pageApplication,
       server: pageServer,
+      metrics: pageMetrics,
       requests: pageRequests,
+      logs: pageLogs,
       loggers: pageLoggers,
       thread: pageThread,
       heap: pageHeap,
@@ -464,6 +618,9 @@
     };
 
     function navigate(page) {
+      // Bump the token so an in-flight loader from the page being left can
+      // detect it is stale and skip rendering. setContent() clears live targets.
+      live.navToken++;
       document.querySelectorAll('[data-page]').forEach(function (a) {
         a.classList.toggle('active', a.dataset.page === page);
       });
@@ -478,6 +635,7 @@
     // Initial route from hash
     var initial = (window.location.hash || '#application').replace(/^#/, '') || 'application';
     navigate(pages[initial] ? initial : 'application');
+    connectStream();
   })();
   </script>
 </body>

--- a/waitt-admin/src/main/resources/public/index.html
+++ b/waitt-admin/src/main/resources/public/index.html
@@ -19,6 +19,7 @@
         <li><a class="nav-link" data-page="server">Server</a></li>
         <li><a class="nav-link" data-page="metrics">Metrics</a></li>
         <li><a class="nav-link" data-page="requests">Request Log</a></li>
+        <li><a class="nav-link" data-page="traces">Traces</a></li>
         <li><a class="nav-link" data-page="logs">Logs</a></li>
         <li><a class="nav-link" data-page="loggers">Loggers</a></li>
         <li><a class="nav-link" data-page="thread">Thread dump</a></li>
@@ -64,6 +65,8 @@
       // them so stream events can't append to a detached, off-screen subtree.
       live.requestsTbody = null;
       live.requestsEmpty = null;
+      live.tracesTbody = null;
+      live.tracesEmpty = null;
       live.logsView = null;
       var c = document.getElementById('content');
       c.innerHTML = '';
@@ -346,6 +349,132 @@
       }).catch(function (e) { setContent(errorMsg(e.message)); });
     }
 
+    function traceRow(t) {
+      var time = t.startEpochMillis ? new Date(t.startEpochMillis).toLocaleTimeString() : '';
+      var cls = t.hasError ? 'req-5xx' : (t.statusCode >= 400 ? 'req-4xx' : '');
+      var counts = (t.spanCount || 0) + 's / ' + (t.sqlCount || 0) + 'q / ' + (t.logCount || 0) + 'log';
+      var row = h('tr', { class: (cls ? cls + ' ' : '') + 'trace-row' }, [
+        h('td', {}, [time]),
+        h('td', {}, [t.method || '']),
+        h('td', {}, [t.path || '']),
+        h('td', {}, [String(t.statusCode || '')]),
+        h('td', {}, [t.durationMillis >= 0 ? t.durationMillis + 'ms' : '']),
+        h('td', {}, [counts]),
+      ]);
+      row.addEventListener('click', function () { showTraceDetail(t.traceId); });
+      return row;
+    }
+
+    function pageTraces() {
+      var token = live.navToken;
+      setContent(loading());
+      apiFetch('/traces').then(function (data) {
+        if (token !== live.navToken) return;
+        var traces = data.traces || [];
+        var div = h('div', {});
+        div.appendChild(h('h2', {}, ['Traces ', h('span', { class: 'live-badge' }, ['live'])]));
+        div.appendChild(h('p', { class: 'text-muted' }, ['Click a row for the correlated request detail (waterfall, SQL, logs, exception). Requires waitt-tracer.']));
+        var table = h('table', {});
+        table.appendChild(h('thead', {}, [h('tr', {}, [
+          h('th', {}, ['Time']), h('th', {}, ['Method']), h('th', {}, ['Path']),
+          h('th', {}, ['Status']), h('th', {}, ['Duration']), h('th', {}, ['spans/sql/logs'])
+        ])]));
+        var tbody = h('tbody', {});
+        traces.forEach(function (t) { tbody.appendChild(traceRow(t)); });
+        table.appendChild(tbody);
+        div.appendChild(table);
+        var empty = h('p', { class: 'text-muted' }, ['No traces yet. Send a request to your app.']);
+        if (traces.length) empty.style.display = 'none';
+        div.appendChild(empty);
+        setContent(div);
+        live.tracesTbody = tbody;
+        live.tracesEmpty = empty;
+      }).catch(function (e) { setContent(errorMsg(e.message)); });
+    }
+
+    function renderWaterfall(spans, windowNanos) {
+      var wrap = h('div', { class: 'waterfall' });
+      if (!spans.length) { wrap.appendChild(h('p', { class: 'text-muted' }, ['No spans.'])); return wrap; }
+      var win = Math.max(1, windowNanos || 0);
+      spans.slice().sort(function (a, b) { return a.startOffsetNanos - b.startOffsetNanos; }).forEach(function (s) {
+        var left = (s.startOffsetNanos / win) * 100;
+        var width = Math.max(0.4, (s.durationNanos / win) * 100);
+        var ms = (s.durationNanos / 1e6).toFixed(1) + 'ms';
+        var barCls = 'wf-bar' + (s.error ? ' wf-error' : (s.database ? ' wf-db' : ''));
+        var bar = h('div', { class: barCls }, [h('span', { class: 'wf-dur' }, [ms])]);
+        bar.style.left = left + '%';
+        bar.style.width = width + '%';
+        bar.title = s.name + ' — ' + ms;
+        var row = h('div', { class: 'wf-row' }, [
+          h('div', { class: 'wf-label', title: s.name }, [s.name]),
+          h('div', { class: 'wf-track' }, [bar]),
+        ]);
+        wrap.appendChild(row);
+      });
+      return wrap;
+    }
+
+    function showTraceDetail(traceId) {
+      live.tracesTbody = null;
+      setContent(loading());
+      apiFetch('/traces/' + encodeURIComponent(traceId)).then(function (t) {
+        var div = h('div', {});
+        var back = h('a', { class: 'nav-link back-link' }, ['← Traces']);
+        back.addEventListener('click', pageTraces);
+        div.appendChild(back);
+        div.appendChild(h('h2', {}, [(t.method || '') + ' ' + (t.path || '')]));
+        var meta = h('p', { class: 'text-muted' }, [
+          'Status ' + (t.statusCode || '?') + ' · ' + (t.durationMillis >= 0 ? t.durationMillis + 'ms' : '?') +
+          ' · trace ' + t.traceId
+        ]);
+        div.appendChild(meta);
+
+        if (t.exception) {
+          div.appendChild(h('h3', { class: 'text-danger' }, ['Exception: ' + (t.exception.type || '')]));
+          div.appendChild(h('p', {}, [t.exception.message || '']));
+          if (t.exception.stack) {
+            var pre = document.createElement('pre'); pre.className = 'stack-trace'; pre.textContent = t.exception.stack;
+            div.appendChild(pre);
+          }
+        }
+
+        div.appendChild(h('h3', {}, ['Timeline']));
+        div.appendChild(renderWaterfall(t.spans || [], t.windowNanos));
+
+        var sqls = t.sqlEvents || [];
+        div.appendChild(h('h3', {}, ['SQL (' + sqls.length + ')']));
+        if (sqls.length) {
+          var sqlTable = h('table', {});
+          sqlTable.appendChild(h('thead', {}, [h('tr', {}, [h('th', {}, ['#']), h('th', {}, ['Duration']), h('th', {}, ['Rows']), h('th', {}, ['Statement'])])]));
+          var sb = h('tbody', {});
+          sqls.forEach(function (q, i) {
+            sb.appendChild(h('tr', q.success ? {} : { class: 'req-5xx' }, [
+              h('td', {}, [String(i + 1)]),
+              h('td', {}, [q.durationMillis + 'ms']),
+              h('td', {}, [q.rowCount >= 0 ? String(q.rowCount) : '']),
+              h('td', {}, [h('code', {}, [q.sql || (q.error || '')])]),
+            ]));
+          });
+          sqlTable.appendChild(sb);
+          div.appendChild(sqlTable);
+        } else {
+          div.appendChild(h('p', { class: 'text-muted' }, ['No SQL captured (requires waitt-jdbc).']));
+        }
+
+        var logs = t.logs || [];
+        div.appendChild(h('h3', {}, ['Logs (' + logs.length + ')']));
+        if (logs.length) {
+          var lv = h('div', { class: 'log-view' });
+          logs.forEach(function (entry) { lv.appendChild(logLineNode(entry)); });
+          div.appendChild(lv);
+        } else {
+          div.appendChild(h('p', { class: 'text-muted' }, ['No correlated logs.']));
+        }
+
+        setContent(div);
+      }).catch(function (e) { setContent(errorMsg(e.message)); });
+    }
+
     function pageMetrics() {
       setContent(loading());
       fetch(BASE + '/prometheus', { headers: { Accept: 'text/plain' } })
@@ -544,6 +673,8 @@
       navToken: 0,
       requestsTbody: null,
       requestsEmpty: null,
+      tracesTbody: null,
+      tracesEmpty: null,
       logsView: null,
       logEntries: [],
       logFilter: '',
@@ -582,6 +713,16 @@
       }
     }
 
+    function onTraceEvent(e) {
+      if (!live.tracesTbody) return;
+      var t = JSON.parse(e.data);
+      live.tracesTbody.insertBefore(traceRow(t), live.tracesTbody.firstChild);
+      if (live.tracesEmpty) live.tracesEmpty.style.display = 'none';
+      while (live.tracesTbody.childNodes.length > 200) {
+        live.tracesTbody.removeChild(live.tracesTbody.lastChild);
+      }
+    }
+
     function onMetricsEvent(e) {
       var el = document.getElementById('live-indicator');
       if (!el) return;
@@ -596,6 +737,7 @@
       es.addEventListener('open', function () { setIndicator('on'); });
       es.addEventListener('error', function () { setIndicator('off'); });
       es.addEventListener('request', onRequestEvent);
+      es.addEventListener('trace', onTraceEvent);
       es.addEventListener('log', onLogEvent);
       es.addEventListener('metrics', onMetricsEvent);
     }
@@ -607,6 +749,7 @@
       server: pageServer,
       metrics: pageMetrics,
       requests: pageRequests,
+      traces: pageTraces,
       logs: pageLogs,
       loggers: pageLoggers,
       thread: pageThread,

--- a/waitt-admin/src/main/resources/public/index.html
+++ b/waitt-admin/src/main/resources/public/index.html
@@ -353,7 +353,7 @@
       var time = t.startEpochMillis ? new Date(t.startEpochMillis).toLocaleTimeString() : '';
       var cls = t.hasError ? 'req-5xx' : (t.statusCode >= 400 ? 'req-4xx' : '');
       var counts = (t.spanCount || 0) + 's / ' + (t.sqlCount || 0) + 'q / ' + (t.logCount || 0) + 'log';
-      var row = h('tr', { class: (cls ? cls + ' ' : '') + 'trace-row' }, [
+      var row = h('tr', { class: (cls ? cls + ' ' : '') + 'trace-row', 'data-trace-id': t.traceId }, [
         h('td', {}, [time]),
         h('td', {}, [t.method || '']),
         h('td', {}, [t.path || '']),
@@ -415,9 +415,11 @@
     }
 
     function showTraceDetail(traceId) {
+      var token = live.navToken;
       live.tracesTbody = null;
       setContent(loading());
       apiFetch('/traces/' + encodeURIComponent(traceId)).then(function (t) {
+        if (token !== live.navToken) return; // navigated away before this resolved
         var div = h('div', {});
         var back = h('a', { class: 'nav-link back-link' }, ['← Traces']);
         back.addEventListener('click', pageTraces);
@@ -716,6 +718,8 @@
     function onTraceEvent(e) {
       if (!live.tracesTbody) return;
       var t = JSON.parse(e.data);
+      // The /traces snapshot and this live event can race; skip if already shown.
+      if (t.traceId && live.tracesTbody.querySelector('[data-trace-id="' + t.traceId + '"]')) return;
       live.tracesTbody.insertBefore(traceRow(t), live.tracesTbody.firstChild);
       if (live.tracesEmpty) live.tracesEmpty.style.display = 'none';
       while (live.tracesTbody.childNodes.length > 200) {

--- a/waitt-admin/src/test/java/net/unit8/waitt/feature/admin/AdminMetricsTest.java
+++ b/waitt-admin/src/test/java/net/unit8/waitt/feature/admin/AdminMetricsTest.java
@@ -1,0 +1,48 @@
+package net.unit8.waitt.feature.admin;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class AdminMetricsTest {
+
+    private AdminMetrics metrics;
+
+    @Before
+    public void setUp() {
+        metrics = new AdminMetrics();
+    }
+
+    @After
+    public void tearDown() {
+        metrics.close();
+    }
+
+    @Test
+    public void recordsHttpRequestWithMethodAndStatusTags() {
+        metrics.recordHttpRequest("GET", 200, 12);
+
+        String scrape = metrics.scrape();
+        assertTrue(scrape.contains("http_server_requests_seconds_count"));
+        assertTrue(scrape.contains("method=\"GET\""));
+        assertTrue(scrape.contains("status=\"200\""));
+    }
+
+    @Test
+    public void countsMultipleRequestsOnSameSeries() {
+        metrics.recordHttpRequest("POST", 500, 5);
+        metrics.recordHttpRequest("POST", 500, 7);
+
+        String scrape = metrics.scrape();
+        // Two requests on the {POST,500} series render a count of 2.0.
+        assertTrue(scrape.contains("http_server_requests_seconds_count{method=\"POST\",status=\"500\",} 2.0"));
+    }
+
+    @Test
+    public void exposesJvmBinderMetrics() {
+        String scrape = metrics.scrape();
+        assertTrue(scrape.contains("jvm_memory_used_bytes"));
+    }
+}

--- a/waitt-admin/src/test/java/net/unit8/waitt/feature/admin/AdminMetricsTest.java
+++ b/waitt-admin/src/test/java/net/unit8/waitt/feature/admin/AdminMetricsTest.java
@@ -36,8 +36,11 @@ public class AdminMetricsTest {
         metrics.recordHttpRequest("POST", 500, 7);
 
         String scrape = metrics.scrape();
-        // Two requests on the {POST,500} series render a count of 2.0.
-        assertTrue(scrape.contains("http_server_requests_seconds_count{method=\"POST\",status=\"500\",} 2.0"));
+        // Two requests on the {POST,500} series render a count of 2.0. Accept the
+        // series with or without the trailing comma before '}' (differs by
+        // Prometheus client format version).
+        assertTrue(scrape.contains("http_server_requests_seconds_count{method=\"POST\",status=\"500\",} 2.0")
+                || scrape.contains("http_server_requests_seconds_count{method=\"POST\",status=\"500\"} 2.0"));
     }
 
     @Test

--- a/waitt-admin/src/test/java/net/unit8/waitt/feature/admin/ConsoleCaptureTest.java
+++ b/waitt-admin/src/test/java/net/unit8/waitt/feature/admin/ConsoleCaptureTest.java
@@ -1,0 +1,84 @@
+package net.unit8.waitt.feature.admin;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class ConsoleCaptureTest {
+
+    private PrintStream savedOut;
+    private PrintStream savedErr;
+    private ByteArrayOutputStream downstream;
+    private ConsoleCapture capture;
+    private LogBuffer buffer;
+
+    @Before
+    public void setUp() {
+        savedOut = System.out;
+        savedErr = System.err;
+        downstream = new ByteArrayOutputStream();
+        // Install a known original stream so we can assert write-through.
+        System.setOut(new PrintStream(downstream));
+        buffer = new LogBuffer(100);
+        capture = new ConsoleCapture(buffer, EventBroadcaster.getInstance());
+        capture.install();
+    }
+
+    @After
+    public void tearDown() {
+        capture.restore();
+        System.setOut(savedOut);
+        System.setErr(savedErr);
+    }
+
+    @Test
+    public void assemblesCompleteLine() {
+        System.out.print("hello world\n");
+        List<LogEntry> logs = buffer.snapshot();
+        assertEquals(1, logs.size());
+        assertEquals("hello world", logs.get(0).text);
+        assertEquals("OUT", logs.get(0).stream);
+    }
+
+    @Test
+    public void assemblesLineSplitAcrossWrites() {
+        System.out.print("abc");
+        System.out.print("def\n");
+        List<LogEntry> logs = buffer.snapshot();
+        assertEquals(1, logs.size());
+        assertEquals("abcdef", logs.get(0).text);
+    }
+
+    @Test
+    public void trailingPartialLineIsNotEmittedUntilNewline() {
+        System.out.print("no newline yet");
+        assertEquals(0, buffer.snapshot().size());
+        System.out.print("\n");
+        assertEquals(1, buffer.snapshot().size());
+    }
+
+    @Test
+    public void stripsCarriageReturn() {
+        System.out.print("windows line\r\n");
+        assertEquals("windows line", buffer.snapshot().get(0).text);
+    }
+
+    @Test
+    public void writesThroughToOriginalStream() {
+        System.out.print("passthrough\n");
+        assertTrue(downstream.toString().contains("passthrough"));
+    }
+
+    @Test
+    public void restoreReinstatesOriginalStream() {
+        PrintStream duringCapture = System.out;
+        capture.restore();
+        assertNotSame(duringCapture, System.out);
+    }
+}

--- a/waitt-admin/src/test/java/net/unit8/waitt/feature/admin/EventBroadcasterTest.java
+++ b/waitt-admin/src/test/java/net/unit8/waitt/feature/admin/EventBroadcasterTest.java
@@ -1,0 +1,73 @@
+package net.unit8.waitt.feature.admin;
+
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class EventBroadcasterTest {
+
+    private final EventBroadcaster broadcaster = EventBroadcaster.getInstance();
+
+    @After
+    public void tearDown() {
+        broadcaster.shutdown();
+    }
+
+    @Test
+    public void deliversPublishedEventToSubscriber() throws Exception {
+        EventBroadcaster.Subscriber subscriber = broadcaster.subscribe();
+        broadcaster.publish("log", "{\"text\":\"hello\"}");
+
+        EventBroadcaster.Event event = subscriber.poll(1000);
+        assertNotNull(event);
+        assertEquals("log", event.type);
+        assertEquals("{\"text\":\"hello\"}", event.data);
+    }
+
+    @Test
+    public void unsubscribeStopsDelivery() throws Exception {
+        EventBroadcaster.Subscriber subscriber = broadcaster.subscribe();
+        broadcaster.unsubscribe(subscriber);
+        broadcaster.publish("log", "{}");
+
+        assertNull(subscriber.poll(50));
+    }
+
+    @Test
+    public void publishDoesNotBlockAndDropsOldestWhenFull() throws Exception {
+        EventBroadcaster.Subscriber subscriber = broadcaster.subscribe();
+        int overflow = EventBroadcaster.QUEUE_CAPACITY + 50;
+
+        // Publishing far past capacity without draining must not block the producer.
+        for (int i = 0; i < overflow; i++) {
+            broadcaster.publish("log", Integer.toString(i));
+        }
+
+        // Exactly QUEUE_CAPACITY events are retained; the oldest were dropped,
+        // so the first retained is event #50.
+        EventBroadcaster.Event first = subscriber.poll(50);
+        assertNotNull(first);
+        assertEquals(Integer.toString(overflow - EventBroadcaster.QUEUE_CAPACITY), first.data);
+
+        int retained = 1;
+        while (subscriber.poll(10) != null) {
+            retained++;
+        }
+        assertEquals(EventBroadcaster.QUEUE_CAPACITY, retained);
+    }
+
+    @Test
+    public void publishWithNoSubscribersIsNoop() {
+        broadcaster.publish("log", "{}"); // must not throw
+        assertEquals(0, broadcaster.subscriberCount());
+    }
+
+    @Test
+    public void subscribeIfBelowEnforcesCapAtomically() {
+        assertNotNull(broadcaster.subscribeIfBelow(2));
+        assertNotNull(broadcaster.subscribeIfBelow(2));
+        assertNull(broadcaster.subscribeIfBelow(2)); // at cap
+        assertEquals(2, broadcaster.subscriberCount());
+    }
+}

--- a/waitt-admin/src/test/java/net/unit8/waitt/feature/admin/LogBufferTest.java
+++ b/waitt-admin/src/test/java/net/unit8/waitt/feature/admin/LogBufferTest.java
@@ -1,0 +1,50 @@
+package net.unit8.waitt.feature.admin;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class LogBufferTest {
+
+    @Test
+    public void snapshotPreservesInsertionOrder() {
+        LogBuffer buffer = new LogBuffer(10);
+        buffer.add(new LogEntry(1, "OUT", "a"));
+        buffer.add(new LogEntry(2, "OUT", "b"));
+        buffer.add(new LogEntry(3, "ERR", "c"));
+
+        List<LogEntry> snapshot = buffer.snapshot();
+        assertEquals(3, snapshot.size());
+        assertEquals("a", snapshot.get(0).text);
+        assertEquals("b", snapshot.get(1).text);
+        assertEquals("c", snapshot.get(2).text);
+    }
+
+    @Test
+    public void appendPastCapacityEvictsOldest() {
+        LogBuffer buffer = new LogBuffer(3);
+        buffer.add(new LogEntry(1, "OUT", "1"));
+        buffer.add(new LogEntry(2, "OUT", "2"));
+        buffer.add(new LogEntry(3, "OUT", "3"));
+        buffer.add(new LogEntry(4, "OUT", "4"));
+
+        List<LogEntry> snapshot = buffer.snapshot();
+        assertEquals(3, snapshot.size());
+        assertEquals("2", snapshot.get(0).text);
+        assertEquals("3", snapshot.get(1).text);
+        assertEquals("4", snapshot.get(2).text);
+    }
+
+    @Test
+    public void capacityIsAtLeastOne() {
+        LogBuffer buffer = new LogBuffer(0);
+        buffer.add(new LogEntry(1, "OUT", "x"));
+        buffer.add(new LogEntry(2, "OUT", "y"));
+
+        List<LogEntry> snapshot = buffer.snapshot();
+        assertEquals(1, snapshot.size());
+        assertEquals("y", snapshot.get(0).text);
+    }
+}

--- a/waitt-admin/src/test/java/net/unit8/waitt/feature/admin/ResponseUtilsTest.java
+++ b/waitt-admin/src/test/java/net/unit8/waitt/feature/admin/ResponseUtilsTest.java
@@ -1,0 +1,26 @@
+package net.unit8.waitt.feature.admin;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ResponseUtilsTest {
+
+    @Test
+    public void acceptsLoopbackOrigins() {
+        assertTrue(ResponseUtils.isLocalOrigin("http://localhost"));
+        assertTrue(ResponseUtils.isLocalOrigin("http://localhost:8080"));
+        assertTrue(ResponseUtils.isLocalOrigin("http://127.0.0.1:1192"));
+        assertTrue(ResponseUtils.isLocalOrigin("http://[::1]:3000"));
+    }
+
+    @Test
+    public void rejectsLookalikeAndForeignOrigins() {
+        // The prefix-match bug: a host that merely starts with "localhost".
+        assertFalse(ResponseUtils.isLocalOrigin("http://localhost.attacker.example"));
+        assertFalse(ResponseUtils.isLocalOrigin("http://evil.example"));
+        assertFalse(ResponseUtils.isLocalOrigin("https://notlocalhost"));
+        assertFalse(ResponseUtils.isLocalOrigin(null));
+        assertFalse(ResponseUtils.isLocalOrigin("garbage"));
+    }
+}

--- a/waitt-admin/src/test/java/net/unit8/waitt/feature/admin/ResponseUtilsTest.java
+++ b/waitt-admin/src/test/java/net/unit8/waitt/feature/admin/ResponseUtilsTest.java
@@ -12,6 +12,7 @@ public class ResponseUtilsTest {
         assertTrue(ResponseUtils.isLocalOrigin("http://localhost:8080"));
         assertTrue(ResponseUtils.isLocalOrigin("http://127.0.0.1:1192"));
         assertTrue(ResponseUtils.isLocalOrigin("http://[::1]:3000"));
+        assertTrue(ResponseUtils.isLocalOrigin("HTTP://LocalHost:8080")); // case-insensitive host
     }
 
     @Test

--- a/waitt-api/pom.xml
+++ b/waitt-api/pom.xml
@@ -18,10 +18,5 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/waitt-api/pom.xml
+++ b/waitt-api/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.unit8.waitt</groupId>
         <artifactId>waitt-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/waitt-api/src/main/java/net/unit8/waitt/api/configuration/Feature.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/configuration/Feature.java
@@ -3,13 +3,11 @@ package net.unit8.waitt.api.configuration;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
-import lombok.Data;
 
 /**
  *
  * @author kawasima
  */
-@Data
 public class Feature implements Serializable {
     private static final long serialVersionUID = 1L;
 
@@ -19,4 +17,19 @@ public class Feature implements Serializable {
     private String type;
 
     private Map<String, String> configuration = new HashMap<>();
+
+    public String getGroupId() { return groupId; }
+    public void setGroupId(String groupId) { this.groupId = groupId; }
+
+    public String getArtifactId() { return artifactId; }
+    public void setArtifactId(String artifactId) { this.artifactId = artifactId; }
+
+    public String getVersion() { return version; }
+    public void setVersion(String version) { this.version = version; }
+
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+
+    public Map<String, String> getConfiguration() { return configuration; }
+    public void setConfiguration(Map<String, String> configuration) { this.configuration = configuration; }
 }

--- a/waitt-api/src/main/java/net/unit8/waitt/api/configuration/FilterConfiguration.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/configuration/FilterConfiguration.java
@@ -1,18 +1,24 @@
 package net.unit8.waitt.api.configuration;
 
-import lombok.Data;
-
 import java.io.Serializable;
 import java.util.List;
 
 /**
  * @author kawasima
  */
-@Data
 public class FilterConfiguration implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private String name;
     private String className;
     private List<String> urlPatterns;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getClassName() { return className; }
+    public void setClassName(String className) { this.className = className; }
+
+    public List<String> getUrlPatterns() { return urlPatterns; }
+    public void setUrlPatterns(List<String> urlPatterns) { this.urlPatterns = urlPatterns; }
 }

--- a/waitt-api/src/main/java/net/unit8/waitt/api/configuration/Server.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/configuration/Server.java
@@ -1,16 +1,23 @@
 package net.unit8.waitt.api.configuration;
 
 import java.io.Serializable;
-import lombok.Data;
 
 /**
  * @author kawasima
  */
-@Data
 public class Server implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private String groupId;
     private String artifactId;
     private String version;
+
+    public String getGroupId() { return groupId; }
+    public void setGroupId(String groupId) { this.groupId = groupId; }
+
+    public String getArtifactId() { return artifactId; }
+    public void setArtifactId(String artifactId) { this.artifactId = artifactId; }
+
+    public String getVersion() { return version; }
+    public void setVersion(String version) { this.version = version; }
 }

--- a/waitt-api/src/main/java/net/unit8/waitt/api/configuration/WebappConfiguration.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/configuration/WebappConfiguration.java
@@ -6,13 +6,11 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import lombok.Data;
 
 /**
  *
  * @author kawasima
  */
-@Data
 public class WebappConfiguration implements Serializable {
     private static final long serialVersionUID = 1L;
 
@@ -21,6 +19,23 @@ public class WebappConfiguration implements Serializable {
     private File sourceDirectory;
     private File outputDirectory;
     private Set<String> packages = new HashSet<>();
-
     private List<Feature> features = new ArrayList<>();
+
+    public String getApplicationName() { return applicationName; }
+    public void setApplicationName(String applicationName) { this.applicationName = applicationName; }
+
+    public File getBaseDirectory() { return baseDirectory; }
+    public void setBaseDirectory(File baseDirectory) { this.baseDirectory = baseDirectory; }
+
+    public File getSourceDirectory() { return sourceDirectory; }
+    public void setSourceDirectory(File sourceDirectory) { this.sourceDirectory = sourceDirectory; }
+
+    public File getOutputDirectory() { return outputDirectory; }
+    public void setOutputDirectory(File outputDirectory) { this.outputDirectory = outputDirectory; }
+
+    public Set<String> getPackages() { return packages; }
+    public void setPackages(Set<String> packages) { this.packages = packages; }
+
+    public List<Feature> getFeatures() { return features; }
+    public void setFeatures(List<Feature> features) { this.features = features; }
 }

--- a/waitt-api/src/main/java/net/unit8/waitt/api/dto/ServerMetadata.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/dto/ServerMetadata.java
@@ -1,13 +1,17 @@
 package net.unit8.waitt.api.dto;
 
-import lombok.Data;
 import net.unit8.waitt.api.ServerStatus;
 
 /**
  * @author kawasima
  */
-@Data
 public class ServerMetadata {
     private String name;
     private ServerStatus status;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public ServerStatus getStatus() { return status; }
+    public void setStatus(ServerStatus status) { this.status = status; }
 }

--- a/waitt-api/src/main/java/net/unit8/waitt/api/observability/LogLine.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/observability/LogLine.java
@@ -1,0 +1,24 @@
+package net.unit8.waitt.api.observability;
+
+/**
+ * One console line correlated to a request. Recorded into the shared
+ * {@link TraceStore} from the console capture running on the request thread.
+ *
+ * @author kawasima
+ */
+public final class LogLine {
+    private final long timestampMillis;
+    private final String stream;
+    private final String text;
+
+    public LogLine(long timestampMillis, String stream, String text) {
+        this.timestampMillis = timestampMillis;
+        this.stream = stream;
+        this.text = text;
+    }
+
+    public long getTimestampMillis() { return timestampMillis; }
+    /** Source of the line, e.g. {@code OUT} or {@code ERR}. */
+    public String getStream() { return stream; }
+    public String getText() { return text; }
+}

--- a/waitt-api/src/main/java/net/unit8/waitt/api/observability/RequestTrace.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/observability/RequestTrace.java
@@ -1,0 +1,64 @@
+package net.unit8.waitt.api.observability;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Everything captured for one HTTP request, keyed by its OpenTelemetry trace id:
+ * the spans (HTTP + any nested), the SQL statements it ran, the console lines it
+ * emitted, and the exception that escaped it. Assembled in {@link TraceStore} and
+ * rendered by the admin dashboard as a correlated request-detail view.
+ *
+ * @author kawasima
+ */
+public final class RequestTrace {
+    private final String traceId;
+    private final long startEpochMillis;
+
+    private volatile String method;
+    private volatile String path;
+    private volatile int statusCode;
+    private volatile long durationMillis = -1;
+
+    private volatile String exceptionType;
+    private volatile String exceptionMessage;
+    private volatile String exceptionStack;
+
+    private final List<SpanRecord> spans = new CopyOnWriteArrayList<SpanRecord>();
+    private final List<SqlEvent> sqlEvents = new CopyOnWriteArrayList<SqlEvent>();
+    private final List<LogLine> logs = new CopyOnWriteArrayList<LogLine>();
+
+    public RequestTrace(String traceId, long startEpochMillis) {
+        this.traceId = traceId;
+        this.startEpochMillis = startEpochMillis;
+    }
+
+    public String getTraceId() { return traceId; }
+    public long getStartEpochMillis() { return startEpochMillis; }
+
+    public String getMethod() { return method; }
+    public void setMethod(String method) { this.method = method; }
+    public String getPath() { return path; }
+    public void setPath(String path) { this.path = path; }
+    public int getStatusCode() { return statusCode; }
+    public void setStatusCode(int statusCode) { this.statusCode = statusCode; }
+    public long getDurationMillis() { return durationMillis; }
+    public void setDurationMillis(long durationMillis) { this.durationMillis = durationMillis; }
+
+    public String getExceptionType() { return exceptionType; }
+    public String getExceptionMessage() { return exceptionMessage; }
+    public String getExceptionStack() { return exceptionStack; }
+    public void setException(String type, String message, String stack) {
+        this.exceptionType = type;
+        this.exceptionMessage = message;
+        this.exceptionStack = stack;
+    }
+
+    public void addSpan(SpanRecord span) { spans.add(span); }
+    public void addSqlEvent(SqlEvent event) { sqlEvents.add(event); }
+    public void addLog(LogLine line) { logs.add(line); }
+
+    public List<SpanRecord> getSpans() { return spans; }
+    public List<SqlEvent> getSqlEvents() { return sqlEvents; }
+    public List<LogLine> getLogs() { return logs; }
+}

--- a/waitt-api/src/main/java/net/unit8/waitt/api/observability/RequestTrace.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/observability/RequestTrace.java
@@ -1,7 +1,7 @@
 package net.unit8.waitt.api.observability;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Everything captured for one HTTP request, keyed by its OpenTelemetry trace id:
@@ -23,10 +23,15 @@ public final class RequestTrace {
     private volatile String exceptionType;
     private volatile String exceptionMessage;
     private volatile String exceptionStack;
+    private volatile String openerSpanId;
 
-    private final List<SpanRecord> spans = new CopyOnWriteArrayList<SpanRecord>();
-    private final List<SqlEvent> sqlEvents = new CopyOnWriteArrayList<SqlEvent>();
-    private final List<LogLine> logs = new CopyOnWriteArrayList<LogLine>();
+    // Single-writer high-frequency appends (all from the request thread); readers
+    // (the admin thread, at request end) get a synchronized snapshot. A plain
+    // synchronized ArrayList beats CopyOnWriteArrayList here, whose per-add full
+    // copy would be O(n^2) for a request that logs many lines.
+    private final List<SpanRecord> spans = new ArrayList<SpanRecord>();
+    private final List<SqlEvent> sqlEvents = new ArrayList<SqlEvent>();
+    private final List<LogLine> logs = new ArrayList<LogLine>();
 
     public RequestTrace(String traceId, long startEpochMillis) {
         this.traceId = traceId;
@@ -35,6 +40,22 @@ public final class RequestTrace {
 
     public String getTraceId() { return traceId; }
     public long getStartEpochMillis() { return startEpochMillis; }
+
+    /**
+     * The span that opened this trace (the first span seen for the trace id).
+     * The trace is finalized when this span ends, which is robust against a
+     * non-root HTTP span (ambient parent) and against nested spans.
+     */
+    public String getOpenerSpanId() { return openerSpanId; }
+
+    /** Claim this trace's opener slot; true only for the first caller. */
+    public synchronized boolean markOpener(String spanId) {
+        if (openerSpanId == null) {
+            openerSpanId = spanId;
+            return true;
+        }
+        return false;
+    }
 
     public String getMethod() { return method; }
     public void setMethod(String method) { this.method = method; }
@@ -54,11 +75,11 @@ public final class RequestTrace {
         this.exceptionStack = stack;
     }
 
-    public void addSpan(SpanRecord span) { spans.add(span); }
-    public void addSqlEvent(SqlEvent event) { sqlEvents.add(event); }
-    public void addLog(LogLine line) { logs.add(line); }
+    public void addSpan(SpanRecord span) { synchronized (spans) { spans.add(span); } }
+    public void addSqlEvent(SqlEvent event) { synchronized (sqlEvents) { sqlEvents.add(event); } }
+    public void addLog(LogLine line) { synchronized (logs) { logs.add(line); } }
 
-    public List<SpanRecord> getSpans() { return spans; }
-    public List<SqlEvent> getSqlEvents() { return sqlEvents; }
-    public List<LogLine> getLogs() { return logs; }
+    public List<SpanRecord> getSpans() { synchronized (spans) { return new ArrayList<SpanRecord>(spans); } }
+    public List<SqlEvent> getSqlEvents() { synchronized (sqlEvents) { return new ArrayList<SqlEvent>(sqlEvents); } }
+    public List<LogLine> getLogs() { synchronized (logs) { return new ArrayList<LogLine>(logs); } }
 }

--- a/waitt-api/src/main/java/net/unit8/waitt/api/observability/SpanRecord.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/observability/SpanRecord.java
@@ -1,0 +1,50 @@
+package net.unit8.waitt.api.observability;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A single span mapped from an OpenTelemetry span into a plain, ClassRealm-neutral
+ * form. Lives in {@code waitt-api} so the tracer realm (which produces it) and the
+ * admin realm (which renders it) share the same type without reflection.
+ *
+ * @author kawasima
+ */
+public final class SpanRecord {
+    private final String spanId;
+    private final String parentSpanId;
+    private final String name;
+    private final long startEpochNanos;
+    private final long endEpochNanos;
+    private final boolean error;
+    private final Map<String, String> attributes;
+
+    public SpanRecord(String spanId, String parentSpanId, String name,
+                      long startEpochNanos, long endEpochNanos, boolean error,
+                      Map<String, String> attributes) {
+        this.spanId = spanId;
+        this.parentSpanId = parentSpanId;
+        this.name = name;
+        this.startEpochNanos = startEpochNanos;
+        this.endEpochNanos = endEpochNanos;
+        this.error = error;
+        this.attributes = attributes == null
+                ? Collections.<String, String>emptyMap()
+                : Collections.unmodifiableMap(new LinkedHashMap<String, String>(attributes));
+    }
+
+    public String getSpanId() { return spanId; }
+    public String getParentSpanId() { return parentSpanId; }
+    public String getName() { return name; }
+    public long getStartEpochNanos() { return startEpochNanos; }
+    public long getEndEpochNanos() { return endEpochNanos; }
+    public long getDurationNanos() { return endEpochNanos - startEpochNanos; }
+    public boolean isError() { return error; }
+    public Map<String, String> getAttributes() { return attributes; }
+
+    /** True when this span carries database attributes (a SQL/JDBC span). */
+    public boolean isDatabase() {
+        return attributes.containsKey("db.statement") || attributes.containsKey("db.system");
+    }
+}

--- a/waitt-api/src/main/java/net/unit8/waitt/api/observability/SqlEvent.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/observability/SqlEvent.java
@@ -1,0 +1,35 @@
+package net.unit8.waitt.api.observability;
+
+/**
+ * One JDBC statement execution captured for a request. Recorded directly into the
+ * shared {@link TraceStore} by a DataSource/Connection proxy running in the webapp
+ * realm — a plain {@code waitt-api} call, no reflection.
+ *
+ * @author kawasima
+ */
+public final class SqlEvent {
+    private final long startEpochMillis;
+    private final long durationMillis;
+    private final String sql;
+    private final int rowCount;
+    private final boolean success;
+    private final String error;
+
+    public SqlEvent(long startEpochMillis, long durationMillis, String sql,
+                    int rowCount, boolean success, String error) {
+        this.startEpochMillis = startEpochMillis;
+        this.durationMillis = durationMillis;
+        this.sql = sql;
+        this.rowCount = rowCount;
+        this.success = success;
+        this.error = error;
+    }
+
+    public long getStartEpochMillis() { return startEpochMillis; }
+    public long getDurationMillis() { return durationMillis; }
+    public String getSql() { return sql; }
+    /** Affected/returned rows, or {@code -1} when unknown. */
+    public int getRowCount() { return rowCount; }
+    public boolean isSuccess() { return success; }
+    public String getError() { return error; }
+}

--- a/waitt-api/src/main/java/net/unit8/waitt/api/observability/TraceStore.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/observability/TraceStore.java
@@ -1,0 +1,157 @@
+package net.unit8.waitt.api.observability;
+
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+/**
+ * Process-wide correlation hub for the dashboard's request-detail view.
+ * <p>
+ * Because this class lives in {@code waitt-api} — the single realm shared by the
+ * webapp, tracer, and admin realms — its static singleton is genuinely one object
+ * across all of them, so producers and the reader share it with plain method calls
+ * (no reflection, no {@code System.getProperties()} handoff).
+ * <p>
+ * Spans arrive from the tracer realm (mapped from OpenTelemetry); SQL and log lines
+ * are recorded from the webapp/request thread and correlated to the in-flight trace
+ * via {@link #currentTraceId()} (a {@link ThreadLocal}). Completed traces are kept
+ * in a bounded ring, newest first.
+ *
+ * @author kawasima
+ */
+public final class TraceStore {
+    private static final TraceStore INSTANCE = new TraceStore();
+
+    public static TraceStore getInstance() { return INSTANCE; }
+
+    private volatile boolean enabled;
+    private volatile int capacity = 100;
+
+    private final Map<String, RequestTrace> active = new ConcurrentHashMap<String, RequestTrace>();
+    private final Deque<RequestTrace> completed = new ConcurrentLinkedDeque<RequestTrace>();
+    private final ThreadLocal<String> currentTraceId = new ThreadLocal<String>();
+    private volatile TraceListener listener;
+
+    private TraceStore() {}
+
+    /** Notified when a trace completes, so the dashboard can push it live. */
+    public interface TraceListener {
+        void onTraceCompleted(RequestTrace trace);
+    }
+
+    public void setListener(TraceListener listener) { this.listener = listener; }
+
+    /** Enabled by the admin feature when the dashboard is present; off by default. */
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+    public boolean isEnabled() { return enabled; }
+
+    public void setCapacity(int capacity) { if (capacity > 0) this.capacity = capacity; }
+
+    // --- trace assembly (driven by the tracer's span processor) ---
+
+    /** Start (or fetch) the in-flight trace for a root span. */
+    public RequestTrace beginTrace(String traceId, long startEpochMillis) {
+        if (!enabled || traceId == null) {
+            return null;
+        }
+        RequestTrace trace = active.get(traceId);
+        if (trace == null) {
+            trace = new RequestTrace(traceId, startEpochMillis);
+            RequestTrace existing = active.putIfAbsent(traceId, trace);
+            if (existing != null) {
+                trace = existing;
+            }
+        }
+        return trace;
+    }
+
+    public void addSpan(String traceId, SpanRecord span) {
+        if (!enabled || traceId == null) {
+            return;
+        }
+        RequestTrace trace = active.get(traceId);
+        if (trace != null) {
+            trace.addSpan(span);
+        }
+    }
+
+    /** Finalize the root span's trace and move it into the completed ring. */
+    public void completeTrace(String traceId) {
+        if (traceId == null) {
+            return;
+        }
+        RequestTrace trace = active.remove(traceId);
+        if (trace == null) {
+            return;
+        }
+        completed.addFirst(trace);
+        while (completed.size() > capacity) {
+            if (completed.pollLast() == null) {
+                break;
+            }
+        }
+        TraceListener l = listener;
+        if (l != null) {
+            try {
+                l.onTraceCompleted(trace);
+            } catch (RuntimeException ignored) {
+                // a listener error must not break span processing
+            }
+        }
+    }
+
+    // --- request-thread correlation (SQL, logs) ---
+
+    public void setCurrentTraceId(String traceId) { currentTraceId.set(traceId); }
+    public void clearCurrentTraceId() { currentTraceId.remove(); }
+    public String currentTraceId() { return currentTraceId.get(); }
+
+    public void recordSql(SqlEvent event) {
+        RequestTrace trace = currentActiveTrace();
+        if (trace != null) {
+            trace.addSqlEvent(event);
+        }
+    }
+
+    public void recordLog(LogLine line) {
+        RequestTrace trace = currentActiveTrace();
+        if (trace != null) {
+            trace.addLog(line);
+        }
+    }
+
+    private RequestTrace currentActiveTrace() {
+        if (!enabled) {
+            return null;
+        }
+        String traceId = currentTraceId.get();
+        return traceId == null ? null : active.get(traceId);
+    }
+
+    // --- read side (admin UI) ---
+
+    public List<RequestTrace> recentTraces() {
+        return new ArrayList<RequestTrace>(completed);
+    }
+
+    public RequestTrace getTrace(String traceId) {
+        if (traceId == null) {
+            return null;
+        }
+        RequestTrace trace = active.get(traceId);
+        if (trace != null) {
+            return trace;
+        }
+        for (RequestTrace t : completed) {
+            if (traceId.equals(t.getTraceId())) {
+                return t;
+            }
+        }
+        return null;
+    }
+
+    public int size() { return completed.size(); }
+}

--- a/waitt-api/src/main/java/net/unit8/waitt/api/observability/TraceStore.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/observability/TraceStore.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Process-wide correlation hub for the dashboard's request-detail view.
@@ -32,6 +33,7 @@ public final class TraceStore {
 
     private final Map<String, RequestTrace> active = new ConcurrentHashMap<String, RequestTrace>();
     private final Deque<RequestTrace> completed = new ConcurrentLinkedDeque<RequestTrace>();
+    private final AtomicInteger completedCount = new AtomicInteger(0);
     private final ThreadLocal<String> currentTraceId = new ThreadLocal<String>();
     private volatile TraceListener listener;
 
@@ -88,10 +90,13 @@ public final class TraceStore {
             return;
         }
         completed.addFirst(trace);
-        while (completed.size() > capacity) {
+        completedCount.incrementAndGet();
+        // O(1) trim: ConcurrentLinkedDeque.size() is O(n), so track the count.
+        while (completedCount.get() > capacity) {
             if (completed.pollLast() == null) {
                 break;
             }
+            completedCount.decrementAndGet();
         }
         TraceListener l = listener;
         if (l != null) {
@@ -153,12 +158,13 @@ public final class TraceStore {
         return null;
     }
 
-    public int size() { return completed.size(); }
+    public int size() { return completedCount.get(); }
 
     /** Drop all retained state (used on shutdown and by tests). */
     public void clear() {
         active.clear();
         completed.clear();
+        completedCount.set(0);
         currentTraceId.remove();
     }
 }

--- a/waitt-api/src/main/java/net/unit8/waitt/api/observability/TraceStore.java
+++ b/waitt-api/src/main/java/net/unit8/waitt/api/observability/TraceStore.java
@@ -154,4 +154,11 @@ public final class TraceStore {
     }
 
     public int size() { return completed.size(); }
+
+    /** Drop all retained state (used on shutdown and by tests). */
+    public void clear() {
+        active.clear();
+        completed.clear();
+        currentTraceId.remove();
+    }
 }

--- a/waitt-api/src/test/java/net/unit8/waitt/api/observability/TraceStoreTest.java
+++ b/waitt-api/src/test/java/net/unit8/waitt/api/observability/TraceStoreTest.java
@@ -94,6 +94,17 @@ public class TraceStoreTest {
         assertEquals("t1", notified.get());
     }
 
+    @Test
+    public void onlyFirstMarkOpenerWins() {
+        RequestTrace t = store.beginTrace("t1", 1L);
+        assertTrue(t.markOpener("spanA"));
+        assertEquals("spanA", t.getOpenerSpanId());
+        // A later span (nested, or the HTTP span under an ambient parent) must not
+        // steal the opener slot — that keeps finalization tied to the right span.
+        assertFalse(t.markOpener("spanB"));
+        assertEquals("spanA", t.getOpenerSpanId());
+    }
+
     private static SpanRecord span(String id, String parent, String name) {
         return new SpanRecord(id, parent, name, 0L, 1_000_000L, false,
                 Collections.<String, String>emptyMap());

--- a/waitt-api/src/test/java/net/unit8/waitt/api/observability/TraceStoreTest.java
+++ b/waitt-api/src/test/java/net/unit8/waitt/api/observability/TraceStoreTest.java
@@ -1,0 +1,101 @@
+package net.unit8.waitt.api.observability;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.*;
+
+public class TraceStoreTest {
+
+    private final TraceStore store = TraceStore.getInstance();
+
+    @Before
+    public void setUp() {
+        store.clear();
+        store.setCapacity(100);
+        store.setListener(null);
+        store.setEnabled(true);
+    }
+
+    @After
+    public void tearDown() {
+        store.setEnabled(false);
+        store.setListener(null);
+        store.clear();
+        store.clearCurrentTraceId();
+    }
+
+    @Test
+    public void disabledStoreDoesNotBeginOrRecord() {
+        store.setEnabled(false);
+        assertNull(store.beginTrace("t1", 1000L));
+        store.setCurrentTraceId("t1");
+        store.recordSql(new SqlEvent(0, 1, "select 1", 1, true, null));
+        assertNull(store.getTrace("t1"));
+    }
+
+    @Test
+    public void beginAddSpanCompleteMovesToRing() {
+        store.beginTrace("t1", 1000L);
+        store.addSpan("t1", span("s1", null, "HTTP GET"));
+        store.completeTrace("t1");
+
+        assertEquals(1, store.recentTraces().size());
+        RequestTrace t = store.getTrace("t1");
+        assertNotNull(t);
+        assertEquals(1, t.getSpans().size());
+    }
+
+    @Test
+    public void currentTraceIdCorrelatesSqlAndLogs() {
+        store.beginTrace("t1", 1000L);
+        store.setCurrentTraceId("t1");
+        store.recordSql(new SqlEvent(0, 3, "select 1", 1, true, null));
+        store.recordLog(new LogLine(0, "OUT", "hello"));
+        store.clearCurrentTraceId();
+
+        RequestTrace t = store.getTrace("t1");
+        assertEquals(1, t.getSqlEvents().size());
+        assertEquals(1, t.getLogs().size());
+        // With no current trace bound, records are dropped.
+        store.recordSql(new SqlEvent(0, 1, "select 2", 0, true, null));
+        assertEquals(1, t.getSqlEvents().size());
+    }
+
+    @Test
+    public void capacityEvictsOldestCompletedTrace() {
+        store.setCapacity(2);
+        for (int i = 1; i <= 3; i++) {
+            store.beginTrace("t" + i, i);
+            store.completeTrace("t" + i);
+        }
+        assertEquals(2, store.recentTraces().size());
+        assertNull(store.getTrace("t1")); // evicted
+        assertNotNull(store.getTrace("t3"));
+        // recentTraces is newest-first.
+        assertEquals("t3", store.recentTraces().get(0).getTraceId());
+    }
+
+    @Test
+    public void listenerFiresOnComplete() {
+        final AtomicReference<String> notified = new AtomicReference<String>();
+        store.setListener(new TraceStore.TraceListener() {
+            @Override
+            public void onTraceCompleted(RequestTrace trace) {
+                notified.set(trace.getTraceId());
+            }
+        });
+        store.beginTrace("t1", 1000L);
+        store.completeTrace("t1");
+        assertEquals("t1", notified.get());
+    }
+
+    private static SpanRecord span(String id, String parent, String name) {
+        return new SpanRecord(id, parent, name, 0L, 1_000_000L, false,
+                Collections.<String, String>emptyMap());
+    }
+}

--- a/waitt-devtools/pom.xml
+++ b/waitt-devtools/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>net.unit8.waitt</groupId>
         <artifactId>waitt-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/waitt-embed-runner/pom.xml
+++ b/waitt-embed-runner/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.unit8.waitt</groupId>
         <artifactId>waitt-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/waitt-embed-runner/pom.xml
+++ b/waitt-embed-runner/pom.xml
@@ -19,11 +19,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>net.unit8.waitt</groupId>
             <artifactId>waitt-api</artifactId>
             <version>${project.parent.version}</version>

--- a/waitt-jacoco/pom.xml
+++ b/waitt-jacoco/pom.xml
@@ -46,11 +46,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
         </dependency>

--- a/waitt-jacoco/pom.xml
+++ b/waitt-jacoco/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>net.unit8.waitt</groupId>
         <artifactId>waitt-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/waitt-jetty12/pom.xml
+++ b/waitt-jetty12/pom.xml
@@ -14,7 +14,7 @@
     </parent>
 
     <properties>
-        <jetty.version>12.1.6</jetty.version>
+        <jetty.version>12.1.8</jetty.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
     </properties>

--- a/waitt-jetty12/pom.xml
+++ b/waitt-jetty12/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>net.unit8.waitt</groupId>
         <artifactId>waitt-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/waitt-maven-plugin/pom.xml
+++ b/waitt-maven-plugin/pom.xml
@@ -12,7 +12,7 @@
     <packaging>maven-plugin</packaging>
 
     <properties>
-        <maven.version>3.9.9</maven.version>
+        <maven.version>3.9.14</maven.version>
         <mavenPluginPluginVersion>3.15.2</mavenPluginPluginVersion>
         <maven.archiver.version>3.6.6</maven.archiver.version>
     </properties>
@@ -110,11 +110,6 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.fusesource.jansi</groupId>

--- a/waitt-maven-plugin/pom.xml
+++ b/waitt-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.unit8.waitt</groupId>
         <artifactId>waitt-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
     <artifactId>waitt-maven-plugin</artifactId>
     <name>waitt-maven-plugin</name>

--- a/waitt-maven-plugin/src/main/java/net/unit8/waitt/mojo/configuration/DockerConfiguration.java
+++ b/waitt-maven-plugin/src/main/java/net/unit8/waitt/mojo/configuration/DockerConfiguration.java
@@ -1,7 +1,5 @@
 package net.unit8.waitt.mojo.configuration;
 
-import lombok.Data;
-
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
@@ -11,7 +9,6 @@ import java.util.List;
  *
  * @author kawasima
  */
-@Data
 public class DockerConfiguration implements Serializable {
     private static final long serialVersionUID = 1L;
 
@@ -21,4 +18,22 @@ public class DockerConfiguration implements Serializable {
     private List<Integer> ports = Collections.singletonList(8080);
     private String javaOpts = "";
     private String to = "daemon";
+
+    public String getBaseImage() { return baseImage; }
+    public void setBaseImage(String baseImage) { this.baseImage = baseImage; }
+
+    public String getImageName() { return imageName; }
+    public void setImageName(String imageName) { this.imageName = imageName; }
+
+    public String getImageTag() { return imageTag; }
+    public void setImageTag(String imageTag) { this.imageTag = imageTag; }
+
+    public List<Integer> getPorts() { return ports; }
+    public void setPorts(List<Integer> ports) { this.ports = ports; }
+
+    public String getJavaOpts() { return javaOpts; }
+    public void setJavaOpts(String javaOpts) { this.javaOpts = javaOpts; }
+
+    public String getTo() { return to; }
+    public void setTo(String to) { this.to = to; }
 }

--- a/waitt-maven-plugin/src/main/java/net/unit8/waitt/mojo/configuration/ExtraWebapp.java
+++ b/waitt-maven-plugin/src/main/java/net/unit8/waitt/mojo/configuration/ExtraWebapp.java
@@ -1,17 +1,23 @@
 package net.unit8.waitt.mojo.configuration;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
 
 /**
  *
  * @author kawasima
  */
-@Data
-@AllArgsConstructor
 public class ExtraWebapp {
-    private String name;
-    private String warPath;
-    private ClassRealm realm;
+    private final String name;
+    private final String warPath;
+    private final ClassRealm realm;
+
+    public ExtraWebapp(String name, String warPath, ClassRealm realm) {
+        this.name = name;
+        this.warPath = warPath;
+        this.realm = realm;
+    }
+
+    public String getName() { return name; }
+    public String getWarPath() { return warPath; }
+    public ClassRealm getRealm() { return realm; }
 }

--- a/waitt-tomcat10/pom.xml
+++ b/waitt-tomcat10/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.unit8.waitt</groupId>
         <artifactId>waitt-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
 
     <groupId>net.unit8.waitt.server</groupId>

--- a/waitt-tomcat10/pom.xml
+++ b/waitt-tomcat10/pom.xml
@@ -14,7 +14,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <tomcat.version>10.1.52</tomcat.version>
+        <tomcat.version>10.1.54</tomcat.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
     </properties>

--- a/waitt-tomcat10/pom.xml
+++ b/waitt-tomcat10/pom.xml
@@ -14,7 +14,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <tomcat.version>10.1.54</tomcat.version>
+        <tomcat.version>10.1.55</tomcat.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
     </properties>

--- a/waitt-tomcat11/pom.xml
+++ b/waitt-tomcat11/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.unit8.waitt</groupId>
         <artifactId>waitt-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
 
     <groupId>net.unit8.waitt.server</groupId>

--- a/waitt-tomcat11/pom.xml
+++ b/waitt-tomcat11/pom.xml
@@ -14,7 +14,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <tomcat.version>11.0.18</tomcat.version>
+        <tomcat.version>11.0.21</tomcat.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
     </properties>

--- a/waitt-tomcat11/pom.xml
+++ b/waitt-tomcat11/pom.xml
@@ -14,7 +14,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <tomcat.version>11.0.21</tomcat.version>
+        <tomcat.version>11.0.22</tomcat.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
     </properties>

--- a/waitt-tomcat9/pom.xml
+++ b/waitt-tomcat9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.unit8.waitt</groupId>
         <artifactId>waitt-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
 
     <groupId>net.unit8.waitt.server</groupId>

--- a/waitt-tomcat9/pom.xml
+++ b/waitt-tomcat9/pom.xml
@@ -15,7 +15,7 @@
 
 
     <properties>
-        <tomcat.version>9.0.115</tomcat.version>
+        <tomcat.version>9.0.117</tomcat.version>
     </properties>
 
     <dependencies>

--- a/waitt-tomcat9/pom.xml
+++ b/waitt-tomcat9/pom.xml
@@ -15,7 +15,7 @@
 
 
     <properties>
-        <tomcat.version>9.0.117</tomcat.version>
+        <tomcat.version>9.0.118</tomcat.version>
     </properties>
 
     <dependencies>

--- a/waitt-tracer/pom.xml
+++ b/waitt-tracer/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>net.unit8.waitt</groupId>
         <artifactId>waitt-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/OtelTracingFilter.java
+++ b/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/OtelTracingFilter.java
@@ -62,12 +62,6 @@ public class OtelTracingFilter implements Filter {
 
             scope = otel.makeCurrent.invoke(span);
             chain.doFilter(request, response);
-
-            int statusCode = res.getStatus();
-            otel.spanSetAttributeLong.invoke(span, "http.response.status_code", (long) statusCode);
-            if (statusCode >= 500) {
-                otel.setStatus.invoke(span, otel.statusError);
-            }
         } catch (IOException | ServletException e) {
             recordError(span, e);
             throw e;
@@ -78,9 +72,22 @@ public class OtelTracingFilter implements Filter {
             recordError(span, e);
             throw new ServletException(e);
         } finally {
+            // Set status in finally so a thrown request still records its code
+            // (the success path would otherwise skip it).
+            recordStatus(span, res.getStatus());
             closeQuietly(scope);
             endQuietly(span);
         }
+    }
+
+    private void recordStatus(Object span, int statusCode) {
+        if (span == null || otel == null) return;
+        try {
+            otel.spanSetAttributeLong.invoke(span, "http.response.status_code", (long) statusCode);
+            if (statusCode >= 500) {
+                otel.setStatus.invoke(span, otel.statusError);
+            }
+        } catch (Exception ignored) {}
     }
 
     private void recordError(Object span, Exception e) {

--- a/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/TraceRetentionProcessor.java
+++ b/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/TraceRetentionProcessor.java
@@ -1,5 +1,6 @@
 package net.unit8.waitt.feature.tracer;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
@@ -22,10 +23,14 @@ import java.util.Map;
  * writes only {@code waitt-api} types, so the admin realm reads them with no
  * reflection.
  * <p>
- * On a root span's start it opens the request's trace and binds the trace id to
- * the current thread (via {@link TraceStore#setCurrentTraceId(String)}) so SQL and
- * console lines emitted on that thread correlate; on the root span's end it
- * finalizes the trace and clears the thread binding.
+ * The <em>first</em> span seen for a trace id opens the trace and binds that id to
+ * the current thread (so SQL and console lines emitted on that thread correlate);
+ * the trace is finalized when that same opener span ends. Keying on the opener
+ * span rather than on "is root" keeps this correct when the HTTP span has an
+ * ambient/incoming parent, and avoids a nested span finalizing the trace early.
+ * <p>
+ * Note: correlation is thread-bound, so it covers synchronous request handling;
+ * work dispatched to other threads (async servlets) is not correlated.
  *
  * @author kawasima
  */
@@ -38,9 +43,9 @@ public class TraceRetentionProcessor implements SpanProcessor {
 
     @Override
     public void onStart(Context parentContext, ReadWriteSpan span) {
-        if (isRoot(span.getParentSpanContext().getSpanId())) {
-            String traceId = span.getSpanContext().getTraceId();
-            store.beginTrace(traceId, System.currentTimeMillis());
+        String traceId = span.getSpanContext().getTraceId();
+        RequestTrace trace = store.beginTrace(traceId, System.currentTimeMillis());
+        if (trace != null && trace.markOpener(span.getSpanContext().getSpanId())) {
             store.setCurrentTraceId(traceId);
         }
     }
@@ -54,14 +59,16 @@ public class TraceRetentionProcessor implements SpanProcessor {
     public void onEnd(ReadableSpan span) {
         SpanData data = span.toSpanData();
         String traceId = data.getTraceId();
-        boolean root = isRoot(data.getParentSpanId());
+        store.addSpan(traceId, toRecord(data));
 
-        store.addSpan(traceId, toRecord(data, root));
-
-        if (root) {
-            finalizeTrace(traceId, data);
-            store.completeTrace(traceId);
-            store.clearCurrentTraceId();
+        RequestTrace trace = store.getTrace(traceId);
+        if (trace != null && data.getSpanId().equals(trace.getOpenerSpanId())) {
+            try {
+                finalizeTrace(trace, data);
+            } finally {
+                store.completeTrace(traceId);
+                store.clearCurrentTraceId();
+            }
         }
     }
 
@@ -74,18 +81,18 @@ public class TraceRetentionProcessor implements SpanProcessor {
         return parentSpanId == null || SpanId.getInvalid().equals(parentSpanId);
     }
 
-    private SpanRecord toRecord(SpanData data, boolean root) {
+    private SpanRecord toRecord(SpanData data) {
         final Map<String, String> attrs = new LinkedHashMap<String, String>();
-        data.getAttributes().forEach(new java.util.function.BiConsumer<io.opentelemetry.api.common.AttributeKey<?>, Object>() {
+        data.getAttributes().forEach(new java.util.function.BiConsumer<AttributeKey<?>, Object>() {
             @Override
-            public void accept(io.opentelemetry.api.common.AttributeKey<?> key, Object value) {
+            public void accept(AttributeKey<?> key, Object value) {
                 attrs.put(key.getKey(), String.valueOf(value));
             }
         });
         boolean error = data.getStatus().getStatusCode() == StatusData.error().getStatusCode();
         return new SpanRecord(
                 data.getSpanId(),
-                root ? null : data.getParentSpanId(),
+                isRoot(data.getParentSpanId()) ? null : data.getParentSpanId(),
                 data.getName(),
                 data.getStartEpochNanos(),
                 data.getEndEpochNanos(),
@@ -93,20 +100,12 @@ public class TraceRetentionProcessor implements SpanProcessor {
                 attrs);
     }
 
-    private void finalizeTrace(String traceId, SpanData data) {
-        RequestTrace trace = store.getTrace(traceId);
-        if (trace == null) {
-            return;
-        }
-        trace.setMethod(attr(data, "http.request.method"));
-        trace.setPath(attr(data, "url.path"));
-        String status = attr(data, "http.response.status_code");
+    private void finalizeTrace(RequestTrace trace, SpanData data) {
+        trace.setMethod(stringAttr(data, "http.request.method"));
+        trace.setPath(stringAttr(data, "url.path"));
+        Long status = data.getAttributes().get(AttributeKey.longKey("http.response.status_code"));
         if (status != null) {
-            try {
-                trace.setStatusCode((int) Double.parseDouble(status));
-            } catch (NumberFormatException ignored) {
-                // leave status unset
-            }
+            trace.setStatusCode(status.intValue());
         }
         trace.setDurationMillis((data.getEndEpochNanos() - data.getStartEpochNanos()) / 1_000_000L);
         extractException(trace, data);
@@ -116,42 +115,21 @@ public class TraceRetentionProcessor implements SpanProcessor {
         for (EventData event : data.getEvents()) {
             if ("exception".equals(event.getName())) {
                 trace.setException(
-                        stringAttr(event, "exception.type"),
-                        stringAttr(event, "exception.message"),
-                        stringAttr(event, "exception.stacktrace"));
+                        eventAttr(event, "exception.type"),
+                        eventAttr(event, "exception.message"),
+                        eventAttr(event, "exception.stacktrace"));
                 return;
             }
         }
     }
 
-    private static String attr(SpanData data, String key) {
-        Object v = data.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey(key));
-        if (v != null) {
-            return String.valueOf(v);
-        }
-        // status_code is a long attribute; fall back to a generic scan.
-        final String[] found = new String[1];
-        data.getAttributes().forEach(new java.util.function.BiConsumer<io.opentelemetry.api.common.AttributeKey<?>, Object>() {
-            @Override
-            public void accept(io.opentelemetry.api.common.AttributeKey<?> k, Object value) {
-                if (k.getKey().equals(key)) {
-                    found[0] = String.valueOf(value);
-                }
-            }
-        });
-        return found[0];
+    private static String stringAttr(SpanData data, String key) {
+        Object v = data.getAttributes().get(AttributeKey.stringKey(key));
+        return v == null ? null : String.valueOf(v);
     }
 
-    private static String stringAttr(EventData event, String key) {
-        final String[] found = new String[1];
-        event.getAttributes().forEach(new java.util.function.BiConsumer<io.opentelemetry.api.common.AttributeKey<?>, Object>() {
-            @Override
-            public void accept(io.opentelemetry.api.common.AttributeKey<?> k, Object value) {
-                if (k.getKey().equals(key)) {
-                    found[0] = String.valueOf(value);
-                }
-            }
-        });
-        return found[0];
+    private static String eventAttr(EventData event, String key) {
+        Object v = event.getAttributes().get(AttributeKey.stringKey(key));
+        return v == null ? null : String.valueOf(v);
     }
 }

--- a/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/TraceRetentionProcessor.java
+++ b/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/TraceRetentionProcessor.java
@@ -1,0 +1,157 @@
+package net.unit8.waitt.feature.tracer;
+
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import io.opentelemetry.sdk.trace.data.EventData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import net.unit8.waitt.api.observability.RequestTrace;
+import net.unit8.waitt.api.observability.SpanRecord;
+import net.unit8.waitt.api.observability.TraceStore;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Retains OpenTelemetry spans in the shared {@link TraceStore} for the dashboard's
+ * request-detail view, mapping each span into the ClassRealm-neutral
+ * {@link SpanRecord}. Runs in the tracer realm (which owns the OTel classes) and
+ * writes only {@code waitt-api} types, so the admin realm reads them with no
+ * reflection.
+ * <p>
+ * On a root span's start it opens the request's trace and binds the trace id to
+ * the current thread (via {@link TraceStore#setCurrentTraceId(String)}) so SQL and
+ * console lines emitted on that thread correlate; on the root span's end it
+ * finalizes the trace and clears the thread binding.
+ *
+ * @author kawasima
+ */
+public class TraceRetentionProcessor implements SpanProcessor {
+    private final TraceStore store;
+
+    public TraceRetentionProcessor(TraceStore store) {
+        this.store = store;
+    }
+
+    @Override
+    public void onStart(Context parentContext, ReadWriteSpan span) {
+        if (isRoot(span.getParentSpanContext().getSpanId())) {
+            String traceId = span.getSpanContext().getTraceId();
+            store.beginTrace(traceId, System.currentTimeMillis());
+            store.setCurrentTraceId(traceId);
+        }
+    }
+
+    @Override
+    public boolean isStartRequired() {
+        return true;
+    }
+
+    @Override
+    public void onEnd(ReadableSpan span) {
+        SpanData data = span.toSpanData();
+        String traceId = data.getTraceId();
+        boolean root = isRoot(data.getParentSpanId());
+
+        store.addSpan(traceId, toRecord(data, root));
+
+        if (root) {
+            finalizeTrace(traceId, data);
+            store.completeTrace(traceId);
+            store.clearCurrentTraceId();
+        }
+    }
+
+    @Override
+    public boolean isEndRequired() {
+        return true;
+    }
+
+    private static boolean isRoot(String parentSpanId) {
+        return parentSpanId == null || SpanId.getInvalid().equals(parentSpanId);
+    }
+
+    private SpanRecord toRecord(SpanData data, boolean root) {
+        final Map<String, String> attrs = new LinkedHashMap<String, String>();
+        data.getAttributes().forEach(new java.util.function.BiConsumer<io.opentelemetry.api.common.AttributeKey<?>, Object>() {
+            @Override
+            public void accept(io.opentelemetry.api.common.AttributeKey<?> key, Object value) {
+                attrs.put(key.getKey(), String.valueOf(value));
+            }
+        });
+        boolean error = data.getStatus().getStatusCode() == StatusData.error().getStatusCode();
+        return new SpanRecord(
+                data.getSpanId(),
+                root ? null : data.getParentSpanId(),
+                data.getName(),
+                data.getStartEpochNanos(),
+                data.getEndEpochNanos(),
+                error,
+                attrs);
+    }
+
+    private void finalizeTrace(String traceId, SpanData data) {
+        RequestTrace trace = store.getTrace(traceId);
+        if (trace == null) {
+            return;
+        }
+        trace.setMethod(attr(data, "http.request.method"));
+        trace.setPath(attr(data, "url.path"));
+        String status = attr(data, "http.response.status_code");
+        if (status != null) {
+            try {
+                trace.setStatusCode((int) Double.parseDouble(status));
+            } catch (NumberFormatException ignored) {
+                // leave status unset
+            }
+        }
+        trace.setDurationMillis((data.getEndEpochNanos() - data.getStartEpochNanos()) / 1_000_000L);
+        extractException(trace, data);
+    }
+
+    private void extractException(RequestTrace trace, SpanData data) {
+        for (EventData event : data.getEvents()) {
+            if ("exception".equals(event.getName())) {
+                trace.setException(
+                        stringAttr(event, "exception.type"),
+                        stringAttr(event, "exception.message"),
+                        stringAttr(event, "exception.stacktrace"));
+                return;
+            }
+        }
+    }
+
+    private static String attr(SpanData data, String key) {
+        Object v = data.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey(key));
+        if (v != null) {
+            return String.valueOf(v);
+        }
+        // status_code is a long attribute; fall back to a generic scan.
+        final String[] found = new String[1];
+        data.getAttributes().forEach(new java.util.function.BiConsumer<io.opentelemetry.api.common.AttributeKey<?>, Object>() {
+            @Override
+            public void accept(io.opentelemetry.api.common.AttributeKey<?> k, Object value) {
+                if (k.getKey().equals(key)) {
+                    found[0] = String.valueOf(value);
+                }
+            }
+        });
+        return found[0];
+    }
+
+    private static String stringAttr(EventData event, String key) {
+        final String[] found = new String[1];
+        event.getAttributes().forEach(new java.util.function.BiConsumer<io.opentelemetry.api.common.AttributeKey<?>, Object>() {
+            @Override
+            public void accept(io.opentelemetry.api.common.AttributeKey<?> k, Object value) {
+                if (k.getKey().equals(key)) {
+                    found[0] = String.valueOf(value);
+                }
+            }
+        });
+        return found[0];
+    }
+}

--- a/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/TracerLifecycle.java
+++ b/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/TracerLifecycle.java
@@ -7,6 +7,7 @@ import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import net.unit8.waitt.api.ConfigurableFeature;
 import net.unit8.waitt.api.EmbeddedServer;
@@ -32,6 +33,7 @@ public class TracerLifecycle implements ServerMonitor, ConfigurableFeature {
 
     private OpenTelemetrySdk sdk;
     private String endpoint = DEFAULT_ENDPOINT;
+    private boolean endpointConfigured = false;
     private String serviceName = "waitt-app";
     private int retentionSize = 100;
 
@@ -47,6 +49,7 @@ public class TracerLifecycle implements ServerMonitor, ConfigurableFeature {
                 if (featureConfig != null) {
                     if (featureConfig.containsKey("otel.endpoint")) {
                         endpoint = featureConfig.get("otel.endpoint");
+                        endpointConfigured = true;
                     }
                     if (featureConfig.containsKey("otel.service.name")) {
                         serviceName = featureConfig.get("otel.service.name");
@@ -72,30 +75,38 @@ public class TracerLifecycle implements ServerMonitor, ConfigurableFeature {
                     ))
             );
 
-            String tracesEndpoint = endpoint.contains("/v1/traces") ? endpoint
-                    : endpoint.endsWith("/") ? endpoint + "v1/traces"
-                    : endpoint + "/v1/traces";
-            OtlpHttpSpanExporter spanExporter = OtlpHttpSpanExporter.builder()
-                    .setEndpoint(tracesEndpoint)
-                    .build();
-
             TraceStore store = TraceStore.getInstance();
             store.setCapacity(retentionSize);
             store.setEnabled(true);
 
-            SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
-                    .addSpanProcessor(BatchSpanProcessor.builder(spanExporter).build())
+            SdkTracerProviderBuilder tracerProviderBuilder = SdkTracerProvider.builder()
                     .addSpanProcessor(new TraceRetentionProcessor(store))
-                    .setResource(resource)
-                    .build();
+                    .setResource(resource);
+
+            // The in-process TraceStore already powers the built-in Traces view, so the
+            // OTLP exporter is opt-in: register it only when an endpoint was explicitly
+            // configured. Otherwise a missing collector would spam connection errors.
+            if (endpointConfigured) {
+                String tracesEndpoint = endpoint.contains("/v1/traces") ? endpoint
+                        : endpoint.endsWith("/") ? endpoint + "v1/traces"
+                        : endpoint + "/v1/traces";
+                OtlpHttpSpanExporter spanExporter = OtlpHttpSpanExporter.builder()
+                        .setEndpoint(tracesEndpoint)
+                        .build();
+                tracerProviderBuilder.addSpanProcessor(BatchSpanProcessor.builder(spanExporter).build());
+            }
 
             sdk = OpenTelemetrySdk.builder()
-                    .setTracerProvider(tracerProvider)
+                    .setTracerProvider(tracerProviderBuilder.build())
                     .build();
 
             Tracer tracer = sdk.getTracer("waitt-tracer");
             System.getProperties().put(TRACER_PROPERTY_KEY, tracer);
-            LOG.info("OpenTelemetry tracer initialized (endpoint=" + endpoint + ", service=" + serviceName + ")");
+            if (endpointConfigured) {
+                LOG.info("OpenTelemetry tracer initialized (OTLP export -> " + endpoint + ", service=" + serviceName + ")");
+            } else {
+                LOG.info("OpenTelemetry tracer initialized (in-process TraceStore only, service=" + serviceName + ")");
+            }
         } catch (Exception e) {
             LOG.log(Level.WARNING, "Failed to initialize OpenTelemetry tracer", e);
         }

--- a/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/TracerLifecycle.java
+++ b/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/TracerLifecycle.java
@@ -109,7 +109,9 @@ public class TracerLifecycle implements ServerMonitor, ConfigurableFeature {
     @Override
     public void stop() {
         System.getProperties().remove(TRACER_PROPERTY_KEY);
-        TraceStore.getInstance().setEnabled(false);
+        TraceStore store = TraceStore.getInstance();
+        store.setEnabled(false);
+        store.clear();
         if (sdk != null) {
             sdk.close();
             LOG.info("OpenTelemetry tracer shut down.");

--- a/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/TracerLifecycle.java
+++ b/waitt-tracer/src/main/java/net/unit8/waitt/feature/tracer/TracerLifecycle.java
@@ -13,6 +13,7 @@ import net.unit8.waitt.api.EmbeddedServer;
 import net.unit8.waitt.api.ServerMonitor;
 import net.unit8.waitt.api.configuration.Feature;
 import net.unit8.waitt.api.configuration.WebappConfiguration;
+import net.unit8.waitt.api.observability.TraceStore;
 
 import java.util.Map;
 import java.util.logging.Level;
@@ -32,6 +33,7 @@ public class TracerLifecycle implements ServerMonitor, ConfigurableFeature {
     private OpenTelemetrySdk sdk;
     private String endpoint = DEFAULT_ENDPOINT;
     private String serviceName = "waitt-app";
+    private int retentionSize = 100;
 
     @Override
     public void config(WebappConfiguration config) {
@@ -48,6 +50,13 @@ public class TracerLifecycle implements ServerMonitor, ConfigurableFeature {
                     }
                     if (featureConfig.containsKey("otel.service.name")) {
                         serviceName = featureConfig.get("otel.service.name");
+                    }
+                    if (featureConfig.containsKey("trace.retention.size")) {
+                        try {
+                            retentionSize = Integer.parseInt(featureConfig.get("trace.retention.size"));
+                        } catch (NumberFormatException e) {
+                            LOG.warning("Invalid trace.retention.size: " + featureConfig.get("trace.retention.size"));
+                        }
                     }
                 }
             }
@@ -70,8 +79,13 @@ public class TracerLifecycle implements ServerMonitor, ConfigurableFeature {
                     .setEndpoint(tracesEndpoint)
                     .build();
 
+            TraceStore store = TraceStore.getInstance();
+            store.setCapacity(retentionSize);
+            store.setEnabled(true);
+
             SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
                     .addSpanProcessor(BatchSpanProcessor.builder(spanExporter).build())
+                    .addSpanProcessor(new TraceRetentionProcessor(store))
                     .setResource(resource)
                     .build();
 
@@ -95,6 +109,7 @@ public class TracerLifecycle implements ServerMonitor, ConfigurableFeature {
     @Override
     public void stop() {
         System.getProperties().remove(TRACER_PROPERTY_KEY);
+        TraceStore.getInstance().setEnabled(false);
         if (sdk != null) {
             sdk.close();
             LOG.info("OpenTelemetry tracer shut down.");


### PR DESCRIPTION
Release v1.6.0.

## Highlights

- **feat(observability)**: Correlated trace store + waterfall UI — the admin dashboard's Traces page shows per-request span waterfalls with correlated logs/exceptions, in-process with no external collector required.
- **fix(tracer)**: OTLP export is now opt-in (registered only when `otel.endpoint` is set), so running without a collector no longer spams connection-refused errors.
- **feat(admin)**: Live dev observability — SSE streaming, log tail, HTTP metrics.
- **chore(deps)**: Bump tomcat-embed-core (9.0.118 / 10.1.55 / 11.0.22); remove Lombok from multiple modules.

Version bump to 1.6.0, tagging, and Maven Central deploy follow on master per the release procedure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)